### PR TITLE
Minor XML corrections

### DIFF
--- a/uportal-war/src/main/resources/properties/contexts/flowsContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/flowsContext.xml
@@ -26,7 +26,7 @@
        xmlns:util="http://www.springframework.org/schema/util"       
        xsi:schemaLocation="
            http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-           http://www.springframework.org/schema/webflow-config http://www.springframework.org/schema/webflow-config/spring-webflow-config-2.0.xsd
+           http://www.springframework.org/schema/webflow-config http://www.springframework.org/schema/webflow-config/spring-webflow-config-2.3.xsd
            http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd">
            
     <!-- Generic Web-Flow helper beans -->

--- a/uportal-war/src/test/resources/org/jasig/portal/io/xml/portlet/test_4-0.portlet.xml
+++ b/uportal-war/src/test/resources/org/jasig/portal/io/xml/portlet/test_4-0.portlet.xml
@@ -37,8 +37,8 @@
     <type>Portlet</type>
     <timeout>600000</timeout>
     <portlet-descriptor xmlns:up="https://source.jasig.org/schemas/uportal">
-        <isFramework>true</isFramework>
-        <portletName>MISSING</portletName>
+        <up:isFramework>true</up:isFramework>
+        <up:portletName>MISSING</up:portletName>
     </portlet-descriptor>
     <parameter>
         <name>portletName</name>


### PR DESCRIPTION
Not sure why, but my Eclipse installation can't validate flowsContext.xml when using webflow-config-2.0.xsd, but does validate when using version 2.3. It seems that switching to 2.3 doesn't cause any problems.

Other file (in tests) contains simple namespace corrections.
