### PR TITLE
Fix for https://issues.jasig.org/browse/UP-3241

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/muniversality/muniversality.xsl
+++ b/uportal-war/src/main/resources/layout/theme/muniversality/muniversality.xsl
@@ -238,7 +238,7 @@
 | Template contents can be any valid XSL or XHTML.
 -->
 <xsl:template name="page.meta">
-    <meta name="viewport" content="width=device-width; initial-scale=1.0;" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="description" content="{upMsg:getMessage('portal.page.meta.description', $USER_LANG)}" />


### PR DESCRIPTION
Trunk fix for https://issues.jasig.org/browse/UP-3241. The contents of the viewport tag should be separated by commas not semi colons.
