### PR TITLE
UP-2670 - updates to grouper composite group service.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/groups/grouper/GrouperEntityGroupStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/grouper/GrouperEntityGroupStore.java
@@ -339,7 +339,7 @@ public class GrouperEntityGroupStore implements IEntityGroupStore,
 
             GcGetMembers gcGetMembers = new GcGetMembers();
             gcGetMembers.addGroupName(group.getLocalKey());
-            gcGetMembers.assignIncludeSubjectDetail(true)
+            gcGetMembers.assignIncludeSubjectDetail(true);
             gcGetMembers.addSourceId("g:gsa");
 
             WsGetMembersResults results = gcGetMembers.execute();


### PR DESCRIPTION
Greetings:

dough.  I apologize for missing the semi-colon:

...

I re-applied the changes to the grouper group store file with the formatting left in tact this time.

The three main issues addressed here are:
1) use group names instead of id keys for a better / more intuitive display 
2) fix issue with groups containing both sub groups and people as members.
3) remove extraneous exception traces that occur during the import process (these harmless exceptions get in the way of finding the real exceptions that cause the import to fail).

Let me know if you need more information.

Thanks.
