### PR TITLE
UP-3255:  Import fails on group_memberships when 3.0 and 3.2 styles are ...

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/io/xml/group/GroupMembershipPortalDataType.java
+++ b/uportal-war/src/main/java/org/jasig/portal/io/xml/group/GroupMembershipPortalDataType.java
@@ -91,8 +91,8 @@ public class GroupMembershipPortalDataType extends AbstractPortalDataType {
 
     private static final List<PortalDataKey> PORTAL_DATA_KEYS = Arrays.asList(
             IMPORT_30_DATA_KEY, IMPORT_32_DATA_KEY, 
-            IMPORT_GROUP_30_DATA_KEY, IMPORT_MEMBERS_30_DATA_KEY,
-            IMPORT_GROUP_32_DATA_KEY, IMPORT_MEMBERS_32_DATA_KEY);
+            IMPORT_GROUP_30_DATA_KEY, IMPORT_GROUP_32_DATA_KEY,
+            IMPORT_MEMBERS_30_DATA_KEY, IMPORT_MEMBERS_32_DATA_KEY);
     private static final Set<PortalDataKey> GROUP_MEMBERS_30_KEYS = ImmutableSet.of(IMPORT_GROUP_30_DATA_KEY, IMPORT_MEMBERS_30_DATA_KEY);
     private static final Set<PortalDataKey> GROUP_MEMBERS_32_KEYS = ImmutableSet.of(IMPORT_GROUP_32_DATA_KEY, IMPORT_MEMBERS_32_DATA_KEY);
     


### PR DESCRIPTION
...mixed

Changed import order to...
- IMPORT_GROUP_30_DATA_KEY
- IMPORT_MEMBERS_30_DATA_KEY
- IMPORT_GROUP_32_DATA_KEY
- IMPORT_MEMBERS_32_DATA_KEY

So all groups go in (in either format) before anymemberships.
