### PR TITLE
Replacing XPath evaluations with hand-written DOM traversing

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/INodeIdResolver.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/INodeIdResolver.java
@@ -1,0 +1,23 @@
+package org.jasig.portal.layout;
+
+import org.w3c.dom.Document;
+
+/**
+ * Implementations of this interface should be used when searching for node identifier. For example, it might be tab
+ * identifier lookup based on channel ID or channel ID lookup by its functional name. Implementations are used when
+ * calling {@link IUserLayout#findNodeId(NodeIdFinder)}. The same behavior can be achieved using XPath expressions (and
+ * vice versa), but traversing DOM "manually" is much faster in some situations. Note that with simple XPath expressions
+ * it might not
+ * 
+ * @author Arvīds Grabovskis
+ */
+public interface INodeIdResolver {
+
+    /**
+     * Traverse the document in order to find the required node identifier.
+     * 
+     * @param document User layout document.
+     * @return The ID of the resolved node, null if there is no match
+     */
+    public String traverseDocument(Document document);
+}

--- a/uportal-war/src/main/java/org/jasig/portal/layout/IUserLayout.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/IUserLayout.java
@@ -140,6 +140,15 @@ public interface IUserLayout {
      * @return The ID of the resolved node, null if there is no match
      */
     public String findNodeId(XPathExpression xpathExpression);
+    
+    /**
+     * This method is for the same use as {@link #findNodeId(XPathExpression)}, but since DOM traversal is much faster
+     * than XPath evaluation, sometimes it is worth to implement manual document traversing.
+     * 
+     * @param finder {@link INodeIdResolver} to use against the layout DOM.
+     * @return The ID of the resolved node, null if there is no match.
+     */
+    public String findNodeId(INodeIdResolver finder);
 
      /**
      * Returns a list of node Ids in the layout.

--- a/uportal-war/src/main/java/org/jasig/portal/layout/PortletSubscribeIdResolver.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/PortletSubscribeIdResolver.java
@@ -1,0 +1,34 @@
+package org.jasig.portal.layout;
+
+import org.apache.commons.lang.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+/**
+ * Returns the subscribe ID of a channel having the passed in functional name or null if it can't find such a channel in
+ * the layout.
+ */
+public class PortletSubscribeIdResolver implements INodeIdResolver {
+	private final String fname;
+
+	/**
+	 * @param fname Functional name of portlet whose subscribe id to search for.
+	 */
+	public PortletSubscribeIdResolver(String fname) {
+		this.fname = fname;
+	}
+
+	@Override
+	public String traverseDocument(Document document) {
+		final NodeList channels = document.getElementsByTagName("channel");
+		for (int i = 0; i < channels.getLength(); i++) {
+			final Element e = (Element) channels.item(i);
+			if (fname.equals(e.getAttribute("fname"))) {
+				String ID = e.getAttribute("ID");
+				return StringUtils.isEmpty(ID) ? null : ID;
+			}
+		}
+		return null;
+	}
+}

--- a/uportal-war/src/main/java/org/jasig/portal/layout/PortletTabIdResolver.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/PortletTabIdResolver.java
@@ -1,0 +1,64 @@
+package org.jasig.portal.layout;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * This class mimics the behaviour of XPath expression '/layout/folder/folder[@ID=$nodeId or
+ * descendant::node()[@ID=$nodeId]]/@ID' - it searches for identifier of tab that contains a node with given identifier.
+ * The rationale behind this method is because it is much faster using DOM introspection (~0.1ms), than XPath queries
+ * (0-60ms <a href="http://stackoverflow.com/questions/6340802/java-xpath-apache-jaxp-implementation-performance">
+ * without optimization</a>).
+ * 
+ * @author Arvīds Grabovskis
+ */
+public class PortletTabIdResolver implements INodeIdResolver {
+    private final String layoutNodeId;
+
+    public PortletTabIdResolver(String layoutNodeId) {
+        this.layoutNodeId = layoutNodeId;
+    }
+
+    @Override
+    public String traverseDocument(Document document) {
+        // '/layout' - layouts
+        for (Node root = document.getFirstChild(); root != null; root = root.getNextSibling()) {
+            // '/layout/folder' - root/header/footer folders
+            for (Node rootFolder = root.getFirstChild(); rootFolder != null; rootFolder = rootFolder.getNextSibling()) {
+                // '/layout/folder/folder' - tabs
+                for (Node tab = rootFolder.getFirstChild(); tab != null; tab = tab.getNextSibling()) {
+                    if (containsElmentWithId(tab, layoutNodeId)) {
+                        return ((Element) tab).getAttribute("ID");
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Recursevly find out whether node contains a folder or channel with given identifier.
+     * 
+     * @param node Where to search.
+     * @param id Identifier to search for.
+     * @return true if node or any of its descendats contain an element with given identifier, false otherwise.
+     */
+    private boolean containsElmentWithId(Node node, String id) {
+        String nodeName = node.getNodeName();
+        if ("channel".equals(nodeName) || "folder".equals(nodeName)) {
+            Element e = (Element) node;
+            if (id.equals(e.getAttribute("ID"))) {
+                return true;
+            }
+            if ("folder".equals(nodeName)) {
+                for (Node child = e.getFirstChild(); child != null; child = child.getNextSibling()) {
+                    if (containsElmentWithId(child, id)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/uportal-war/src/main/java/org/jasig/portal/layout/dlm/DistributedLayoutManager.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/dlm/DistributedLayoutManager.java
@@ -1290,15 +1290,8 @@ public class DistributedLayoutManager implements IUserLayoutManager, IFolderLoca
      */
     @Override
     public String getSubscribeId(String fname) {
-    	final Map<String, String> variables = Collections.singletonMap("fname", fname);
-    	
     	final Document userLayout = this.getUserLayoutDOM();
-    	final Element fnameNode = this.xpathOperations.evaluate("//channel[@fname=$fname]", variables, userLayout, XPathConstants.NODE);
-		if (fnameNode != null) {
-			return fnameNode.getAttribute("ID");
-		}
-    	
-    	return null;
+        return new PortletSubscribeIdResolver(fname).traverseDocument(userLayout);
     }
     
     public String getSubscribeId(String parentFolderId, String fname) {

--- a/uportal-war/src/main/java/org/jasig/portal/layout/simple/SimpleLayout.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/simple/SimpleLayout.java
@@ -33,6 +33,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portal.PortalException;
 import org.jasig.portal.layout.IUserLayout;
+import org.jasig.portal.layout.INodeIdResolver;
 import org.jasig.portal.layout.dlm.DistributedUserLayout;
 import org.jasig.portal.layout.node.IUserLayoutFolderDescription;
 import org.jasig.portal.layout.node.IUserLayoutNodeDescription;
@@ -192,6 +193,11 @@ public class SimpleLayout implements IUserLayout {
         catch (XPathExpressionException e) {
             throw new PortalException("Exception while executing XPathExpression: " + xpathExpression, e);
         }
+    }
+    
+    @Override
+    public String findNodeId(INodeIdResolver finder) {
+        return finder.traverseDocument(this.layout);
     }
 
     @Override

--- a/uportal-war/src/main/java/org/jasig/portal/url/SingleTabUrlNodeSyntaxHelper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/SingleTabUrlNodeSyntaxHelper.java
@@ -33,6 +33,7 @@ import org.jasig.portal.concurrency.caching.RequestCache;
 import org.jasig.portal.layout.IStylesheetUserPreferencesService;
 import org.jasig.portal.layout.IUserLayout;
 import org.jasig.portal.layout.IUserLayoutManager;
+import org.jasig.portal.layout.PortletTabIdResolver;
 import org.jasig.portal.layout.node.IUserLayoutNodeDescription;
 import org.jasig.portal.layout.om.IStylesheetUserPreferences;
 import org.jasig.portal.portlet.om.IPortletDefinition;
@@ -168,15 +169,7 @@ public class SingleTabUrlNodeSyntaxHelper implements IUrlNodeSyntaxHelper {
         final IUserLayoutManager userLayoutManager = preferencesManager.getUserLayoutManager();
         final IUserLayout userLayout = userLayoutManager.getUserLayout();
         
-        final String tabId = this.xpathOperations.doWithExpression(
-                tabIdExpression, 
-                Collections.singletonMap("nodeId", layoutNodeId), 
-                new Function<XPathExpression, String>() {
-                    @Override
-                    public String apply(XPathExpression xPathExpression) {
-                        return userLayout.findNodeId(xPathExpression);
-                    }
-                });
+        final String tabId = userLayout.findNodeId(new PortletTabIdResolver(layoutNodeId));
         
         if (StringUtils.isEmpty(tabId)) {
             return Collections.emptyList();


### PR DESCRIPTION
This patch considerably increases performance since each URL generation invokes slow XPath evaluation.
