### PR TITLE
Enable the developer to set custom filters properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.ant-targets-build.xml
 *.sass-cache
 /uportal-impl
+/filters/custom.properties


### PR DESCRIPTION
Ignore `filters/custom.properties`.

Doing this, the developer can use his own configuration properties out of version control :
`ant -Denv=custom`
