### PR TITLE
UP-3501 Removed the new user link for CAS logins

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/universality/components.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/components.xsl
@@ -342,11 +342,6 @@
       <a id="portalCASLoginLink" class="button" href="{$EXTERNAL_LOGIN_URL}" title="{upMsg:getMessage('sign.in.via.cas', $USER_LANG)}">
         <span><xsl:value-of select="upMsg:getMessage('sign.in', $USER_LANG)"/><!--&#160;<span class="via-cas"><xsl:value-of select="upMsg:getMessage('with.cas', $USER_LANG)"/></span>--></span>
       </a>
-      <p><xsl:value-of select="upMsg:getMessage('new.user.question', $USER_LANG)"/>&#160; 
-        <a id="portalCASLoginNewLink" href="{$CAS_NEW_USER_URL}" title="{upMsg:getMessage('create.new.portal.account', $USER_LANG)}">
-          <xsl:value-of select="upMsg:getMessage('new.user', $USER_LANG)"/>
-        </a>.
-      </p>
     </div>
   </xsl:template>
   <!-- ========================================= -->


### PR DESCRIPTION
UP-3501 Removed the new user link for CAS logins since you can't actually create an account. The link just took you to http://jasig.org/cas.

There is info on the front page of the portal about how to login and what accounts people can use, so they can still login.

This also resolves UP-3249 since the text no longer appears.

Screenshot of what it looks like afterwards: https://skitch.com/steveswinsburg/edwg8/uportal-welcome
