### PR TITLE
UP-3249 use mobile detect library to detect mobile devices

### DIFF
--- a/filters/local.properties
+++ b/filters/local.properties
@@ -53,3 +53,6 @@ environment.build.uportal.email.fromAddress=portal@university.edu
 # CAS server configuration properties
 environment.build.cas.server=localhost:8080
 environment.build.cas.protocol=http
+
+# Mobile portal detection. Default false. Set to true to send tablet devices to the mobile portal view.
+tabletsUseMobileView=false

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
         <junit.version>4.10</junit.version>
         <log4j.version>1.2.16</log4j.version>
         <mail.version>1.4.5</mail.version>
+        <mobiledetect.version>1.1.0</mobiledetect.version>
         <mockito.version>1.9.0</mockito.version>
         <objenesis.version>1.2</objenesis.version>
         <org.springframework.webflow.version>2.3.1.RELEASE</org.springframework.webflow.version>
@@ -214,6 +215,11 @@
                 <groupId>aopalliance</groupId>
                 <artifactId>aopalliance</artifactId>
                 <version>${aopalliance.version}</version>
+            </dependency>
+			<dependency>
+                <groupId>au.com.flyingkite</groupId>
+                <artifactId>mobiledetect</artifactId>
+                <version>${mobiledetect.version}</version>
             </dependency>
             <dependency>
                 <groupId>cglib</groupId>

--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
         
         <dependency>
+			<groupId>au.com.flyingkite</groupId>
+			<artifactId>mobiledetect</artifactId>
+		</dependency>
+        
+        <dependency>
             <groupId>org.jasig.cas.client</groupId>
             <artifactId>cas-client-core</artifactId>
         </dependency>
@@ -139,7 +144,7 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
-
+        
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>

--- a/uportal-war/src/main/java/org/jasig/portal/layout/UserAgentProfileMapper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/UserAgentProfileMapper.java
@@ -19,41 +19,34 @@
 
 package org.jasig.portal.layout;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.Validate;
 import org.jasig.portal.security.IPerson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import au.com.flyingkite.mobiledetect.UAgentInfo;
+
 /**
- * Maps User-Agents to profile names using regular expressions. A list of {@link Mapping}s is evaluated in
- * order and the first match is returned. If the user agent header is null or no match is found the 
- * {@link #setDefaultProfileName(String)} value is used.
+ * Maps User-Agents to profile names using the {@link UAgentInfo}class from mobile-detect. Can cater for many different mobile devices
+ * and tablets. If no match is found the {@link #setDefaultProfileName(String)} value is used.
  * 
  * @author Eric Dalquist
+ * @author Steve Swinsburg
  * @version $Revision$
  */
 public class UserAgentProfileMapper implements IProfileMapper {
     protected Logger logger = LoggerFactory.getLogger(getClass());
     
-    private List<Mapping> mappings = Collections.emptyList();
     private String defaultProfileName = null;
     private String userAgentHeader = "User-Agent";
+    private String httpAcceptHeader = "Accept";
+    private boolean tabletsUseMobileView = false;
     
+    private final String MOBILE_PROFILE_NAME = "mobileDefault";
     
-    /**
-     * Regular expression to Profile name mappings.
-     */
-    public void setMappings(List<Mapping> mappings) {
-        this.mappings = mappings;
-    }
-
     /**
      * Default profile name to return if no match is found, defaults to <code>null</code>.
      */
@@ -68,6 +61,13 @@ public class UserAgentProfileMapper implements IProfileMapper {
         Validate.notNull(userAgentHeader);
         this.userAgentHeader = userAgentHeader;
     }
+    
+    /**
+     * Should tablets get the mobile view? Defaults to false if not set
+     */
+    public void setTabletsUseMobileView(String tabletsUseMobileView) {
+    	this.tabletsUseMobileView = BooleanUtils.toBoolean(tabletsUseMobileView);
+    }
 
     /* (non-Javadoc)
      * @see org.jasig.portal.layout.IProfileMapper#getProfileFname(org.jasig.portal.security.IPerson, javax.servlet.http.HttpServletRequest)
@@ -76,78 +76,33 @@ public class UserAgentProfileMapper implements IProfileMapper {
     public String getProfileFname(IPerson person, HttpServletRequest request) {
         final String userAgent = request.getHeader(this.userAgentHeader);
         if (userAgent == null) {
-            this.logger.debug("No {} header for {} returning default profile", this.userAgentHeader, person.getUserName());
+            logger.debug("No {} header for {} returning default profile", this.userAgentHeader, person.getUserName());
             return this.defaultProfileName;
         }
         
-        for (final Mapping mapping : this.mappings) {
-            final Matcher matcher = mapping.pattern.matcher(userAgent);
-            if (matcher.matches()) {
-                this.logger.debug("Matched {} header {} for {} returning profile {}", 
-                        new Object[] {this.userAgentHeader, person.getUserName(), mapping.profileName});
-                return mapping.profileName;
+        String acceptHeader = request.getHeader(this.httpAcceptHeader);
+        if (acceptHeader == null) {
+            logger.debug("No {} header for {}, continuing but may not be able to determine profile correctly", this.httpAcceptHeader, person.getUserName());
+            acceptHeader = "";
+        }
+        
+        UAgentInfo agentInfo = new UAgentInfo(userAgent, acceptHeader);
+        
+        //check mobile device
+        if(agentInfo.detectMobileQuick()) {
+        	logger.debug("Matched {} header {} for {} returning profile {}", new Object[] {this.userAgentHeader, person.getUserName(), MOBILE_PROFILE_NAME});
+        	return MOBILE_PROFILE_NAME;
+        }
+        
+    	//check tablets if configured
+        if(tabletsUseMobileView) {
+        	if(agentInfo.detectTierTablet()) {
+            	logger.debug("Matched {} header {} for {} returning profile {}", new Object[] {this.userAgentHeader, person.getUserName(), MOBILE_PROFILE_NAME});
+            	return MOBILE_PROFILE_NAME;
             }
         }
         
-        this.logger.debug("No matching Mapping for {} header for {} returning default profile", this.userAgentHeader, person.getUserName());
+        logger.debug("No matching Mapping for {} header for {} returning default profile", this.userAgentHeader, person.getUserName());
         return defaultProfileName;
-    }
-    
-    public static class Mapping {
-        private Pattern pattern;
-        private String profileName;
-        
-        public void setPattern(String pattern) {
-            this.pattern = Pattern.compile(pattern);
-        }
-        
-        public void setProfileName(String profileName) {
-            this.profileName = profileName;
-        }
-
-        @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((this.pattern == null) ? 0 : this.pattern.hashCode());
-            result = prime * result + ((this.profileName == null) ? 0 : this.profileName.hashCode());
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null) {
-                return false;
-            }
-            if (getClass() != obj.getClass()) {
-                return false;
-            }
-            Mapping other = (Mapping) obj;
-            if (this.pattern == null) {
-                if (other.pattern != null) {
-                    return false;
-                }
-            }
-            else if (!this.pattern.equals(other.pattern)) {
-                return false;
-            }
-            if (this.profileName == null) {
-                if (other.profileName != null) {
-                    return false;
-                }
-            }
-            else if (!this.profileName.equals(other.profileName)) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public String toString() {
-            return "Mapping [pattern=" + this.pattern + ", profileName=" + this.profileName + "]";
-        }
     }
 }

--- a/uportal-war/src/main/resources/properties/contexts/userContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/userContext.xml
@@ -46,45 +46,7 @@
                 <bean class="org.jasig.portal.layout.SessionAttributeProfileMapperImpl"
                     p:mappings-ref="profileKeyMappings"/>
                 <bean class="org.jasig.portal.layout.UserAgentProfileMapper">
-                    <property name="mappings">
-                        <list>
-                            <!-- Apple iPad -->
-                            <bean class="org.jasig.portal.layout.UserAgentProfileMapper.Mapping">
-                                <property name="pattern" value=".*iPad.*" />
-                                <property name="profileName" value="default" />
-                            </bean>
-                            <!-- Apple iPhone -->
-                            <bean class="org.jasig.portal.layout.UserAgentProfileMapper.Mapping">
-                                <property name="pattern" value=".*iPhone.*" />
-                                <property name="profileName" value="mobileDefault" />
-                            </bean>
-                            <!-- Android -->
-                            <bean class="org.jasig.portal.layout.UserAgentProfileMapper.Mapping">
-                                <property name="pattern" value=".*Android.*Mobile.*" />
-                                <property name="profileName" value="mobileDefault" />
-                            </bean>
-                            <!-- Palm Pre -->
-                            <bean class="org.jasig.portal.layout.UserAgentProfileMapper.Mapping">
-                                <property name="pattern" value=".*Safari.*Pre.*" />
-                                <property name="profileName" value="mobileDefault" />
-                            </bean>
-                            <!-- Nokia S60 web browser -->
-                            <bean class="org.jasig.portal.layout.UserAgentProfileMapper.Mapping">
-                                <property name="pattern" value=".*Nokia.*AppleWebKit.*" />
-                                <property name="profileName" value="mobileDefault" />
-                            </bean>
-                            <!-- Blackberry web browser -->
-                            <bean class="org.jasig.portal.layout.UserAgentProfileMapper.Mapping">
-                                <property name="pattern" value=".*Black[Bb]erry.*" />
-                                <property name="profileName" value="mobileDefault" />
-                            </bean>
-                            <!-- Opera Mobile web browser -->
-                            <bean class="org.jasig.portal.layout.UserAgentProfileMapper.Mapping">
-                                <property name="pattern" value=".*Opera Mobile.*" />
-                                <property name="profileName" value="mobileDefault" />
-                            </bean>
-                        </list>
-                    </property>
+                	<property name="tabletsUseMobileView" value="${tabletsUseMobileView}" />
                 </bean>
             </util:list>
         </property>

--- a/uportal-war/src/test/java/org/jasig/portal/layout/UserAgentProfileMapperImplTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/layout/UserAgentProfileMapperImplTest.java
@@ -18,14 +18,11 @@
  */
 package org.jasig.portal.layout;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
+
 import javax.servlet.http.HttpServletRequest;
 
-import org.jasig.portal.layout.UserAgentProfileMapper.Mapping;
 import org.jasig.portal.security.IPerson;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,17 +41,6 @@ public class UserAgentProfileMapperImplTest {
         
         mapper.setDefaultProfileName("profile");
         mapper.setUserAgentHeader("agent");
-        
-        List<Mapping> mappings = new ArrayList<Mapping>();
-        Mapping mapping1 = new Mapping();
-        mapping1.setPattern(".*iPad.*");
-        mapping1.setProfileName("tablet");
-        Mapping mapping2 = new Mapping();
-        mapping2.setPattern(".*iOS.*");
-        mapping2.setProfileName("mobile");
-        mappings.add(mapping1);
-        mappings.add(mapping2);
-        mapper.setMappings(mappings);
     }
 
     @Test
@@ -64,14 +50,12 @@ public class UserAgentProfileMapperImplTest {
     }
     
     @Test
-    public void testMatchProfile() {
-        when(request.getHeader("agent")).thenReturn("iPad iOS", "iPhone iOS");
-        
-        final String fname1 = mapper.getProfileFname(person, request);
-        assertEquals("tablet", fname1);
-        
-        final String fname2 = mapper.getProfileFname(person, request);
-        assertEquals("mobile", fname2);
+    public void testMobileProfile() {
+        when(request.getHeader("agent")).thenReturn("iPhone", "Android", "Blackberry");
+                
+        final String fname = mapper.getProfileFname(person, request);
+        assertEquals("mobileDefault", fname);
+       
     }
     
 }


### PR DESCRIPTION
This uses the mobile-detect library which is in Maven Central and based on MobileESP, to detect mobile devices, and optionally tablet devices, instead of the single list of user agents that are currently being used. 

Detecting tablets is configurable via local.properties, defaults false as per current behaviour.
