### PR TITLE
UP-3538 Updated salon.com quick start portlet to use new RSS feed.

### DIFF
--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/salon.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/salon.portlet-definition.xml
@@ -48,7 +48,7 @@
     <portlet-preference>
         <name>url</name>
         <readOnly>false</readOnly>
-        <value>http://www.salon.com/feed/RDF/salon_use.rdf</value>
+        <value>http://www.salon.com/feed/</value>
     </portlet-preference>
     <portlet-preference>
         <name>summaryView</name>


### PR DESCRIPTION
The old salon.com feed returns 404. Need to switch to the new one at http://www.salon.com/feed/
