### PR TITLE
improvement for UP-3454

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/muniversality/muniversality.xsl
+++ b/uportal-war/src/main/resources/layout/theme/muniversality/muniversality.xsl
@@ -301,7 +301,7 @@
 | Template contents can be any valid XSL or XHTML.
 -->
 <xsl:template match="/">
-    <html lang="{substring-before($USER_LANG,'-')}">
+    <html lang="$USER_LANG">
         <head>
             <xsl:call-template name="page.title" />
             <xsl:call-template name="page.meta" />

--- a/uportal-war/src/main/resources/layout/theme/universality/page.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/page.xsl
@@ -83,7 +83,7 @@
       </xsl:choose>
     </xsl:variable>
     
-    <html lang="{substring-before($USER_LANG,'-')}">
+    <html lang="$USER_LANG">
       <head>
         <title>
           <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->


### PR DESCRIPTION
I will make a small improvement for the 4.0.6 ...
Without causing problems for accessibility_, we can have the html tag like that:
html lang="en-US"
or
html lang="en-GB"
or
html lang="fr-FR"
or
html lang="fr-CA"
The layouts can be adapted very precisely in css according to Americans, English_*, French, Canadian French, etc..
- I got the confirmation by the WCAG2 working group.
  *\* Yeah, with this you can distinguish in css between American and English...
