### PR TITLE
UP-3591: Instead of returning null preference value, returns specified default value.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlet/container/services/AbstractPortletPreferencesImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/container/services/AbstractPortletPreferencesImpl.java
@@ -151,10 +151,10 @@ public abstract class AbstractPortletPreferencesImpl<C> implements PortletPrefer
         if (portletPreference != null) {
             final String[] values = portletPreference.getValues();
             if (values == null || values.length == 0) {
-                return null;
+                return def;
             }
             
-            return values[0];
+            return values[0] != null ? values[0] : def; // A null value is treated as a non-existent value
         }
         
         return def;

--- a/uportal-war/src/test/java/org/jasig/portal/portlet/container/services/AbstractPortletPreferencesImplTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/portlet/container/services/AbstractPortletPreferencesImplTest.java
@@ -131,17 +131,29 @@ public class AbstractPortletPreferencesImplTest {
         String value = portletPreferences.getValue("key0", "FOOBAR");
         assertEquals("FOOBAR", value);
         
+        // Next 3 asserts check whether null values are treated like non-existent values as specified in
+        // PortletPreferences#getValue(String, String)
         value = portletPreferences.getValue("key1", "FOOBAR");
-        assertNull(value);
+        assertEquals("FOOBAR", value);
         
         value = portletPreferences.getValue("key2", "FOOBAR");
-        assertNull(value);
+        assertEquals("FOOBAR", value);
         
         value = portletPreferences.getValue("key3", "FOOBAR");
-        assertNull(value);
+        assertEquals("FOOBAR", value);
         
         value = portletPreferences.getValue("key4", "FOOBAR");
         assertEquals("value1", value);
+        
+        value = portletPreferences.getValue("key1", null);
+        assertNull(value);
+        
+        value = portletPreferences.getValue("key2", null);
+        assertNull(value);
+        
+        
+        value = portletPreferences.getValue("key3", null);
+        assertNull(value);
     }
     
     @Test


### PR DESCRIPTION
This fix should be reviewed in order to verify that "A null value is treated as a non-existent value." (as specified in Portlet API) should be interpreted as proposed pull request is implemented. It is not perfectly clear whether value refers to an array as a whole or individual array entries. These changes assume the latter variant.
