### PR TITLE
Quoting username in SingleTabUrlNodeSyntaxHelper WARN log message

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/url/SingleTabUrlNodeSyntaxHelper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/SingleTabUrlNodeSyntaxHelper.java
@@ -129,14 +129,14 @@ public class SingleTabUrlNodeSyntaxHelper implements IUrlNodeSyntaxHelper {
             }
         }
     
-        this.logger.warn("Failed to find default tab id for " + userInstance.getPerson().getUserName() + " with default tab index " + defaultTabIndex + ". Index 1 will be tried as a fall-back.");
+        this.logger.warn("Failed to find default tab id for \"" + userInstance.getPerson().getUserName() + "\" with default tab index " + defaultTabIndex + ". Index 1 will be tried as a fall-back.");
         
         final String firstTabId = getTabId(userLayout, "1");
         if (StringUtils.isNotEmpty(firstTabId)) {
             return firstTabId;
         }
         
-        this.logger.warn("Failed to find default tab id for " + userInstance.getPerson().getUserName() + " with default tab index 1. The user has no tabs.");
+        this.logger.warn("Failed to find default tab id for \"" + userInstance.getPerson().getUserName() + "\" with default tab index 1. The user has no tabs.");
         
         return userLayout.getRootId();
     }


### PR DESCRIPTION
To clearly delineate where the username starts and ends.

This would have been helpful whilst troubleshooting an issue where the user was including a trailing space when authenticating. 
