### PR TITLE
UP-3621: Refactor clearPass support for uPortal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -703,10 +703,10 @@
                 </exclusions>
             </dependency>
             <dependency>
-				<groupId>org.jasig.cas</groupId>
-				<artifactId>cas-server-extension-clearpass</artifactId>
-				<version>${cas-server.version}</version>
-			</dependency>
+              <groupId>org.jasig.cas</groupId>
+              <artifactId>cas-server-extension-clearpass</artifactId>
+              <version>${cas-server.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.jasig.portal</groupId>
                 <artifactId>uportal-ear-deployer</artifactId>

--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/cas/clearpass/PasswordCachingCasAssertionSecurityContext.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/cas/clearpass/PasswordCachingCasAssertionSecurityContext.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.security.provider.cas.clearpass;
+
+import org.jasig.cas.client.util.CommonUtils;
+import org.jasig.cas.client.util.XmlUtils;
+import org.jasig.cas.client.validation.Assertion;
+import org.jasig.portal.security.IOpaqueCredentials;
+import org.jasig.portal.security.provider.NotSoOpaqueCredentials;
+import org.jasig.portal.security.provider.cas.CasAssertionSecurityContext;
+import org.springframework.util.Assert;
+
+/**
+ * @author Scott Battaglia
+ */
+public class PasswordCachingCasAssertionSecurityContext extends CasAssertionSecurityContext {
+
+    private static final long serialVersionUID = -3816036745827152340L;
+
+    private final String clearPassUrl;
+
+    private byte[] cachedCredentials;
+
+    protected PasswordCachingCasAssertionSecurityContext(final String clearPassUrl) {
+        super();
+        Assert.notNull(clearPassUrl, "clearPassUrl cannot be null.");
+        this.clearPassUrl = clearPassUrl;
+    }
+
+    @Override
+    protected final void postAuthenticate(final Assertion assertion) {
+        final String proxyTicket = assertion.getPrincipal().getProxyTicketFor(this.clearPassUrl);
+
+        if (proxyTicket == null) {
+            log.error("Unable to obtain proxy ticket for ClearPass service.");
+            return;
+        }
+
+        final String password = retrievePasswordFromResponse(proxyTicket);
+
+        if (password != null) {
+            log.debug("Password retrieved from ClearPass.");
+            this.cachedCredentials = password.getBytes();
+        } else {
+            log.debug("Unable to retrieve password from ClearPass.");
+        }
+    }
+
+    @Override
+    public final IOpaqueCredentials getOpaqueCredentials() {
+        if (this.cachedCredentials == null) {
+            return super.getOpaqueCredentials();
+        }
+
+        final NotSoOpaqueCredentials credentials = new CacheOpaqueCredentials();
+        credentials.setCredentials(this.cachedCredentials);
+        return credentials;
+    }
+
+    protected final String retrievePasswordFromResponse(final String proxyTicket) {
+        final String url = this.clearPassUrl + (this.clearPassUrl.contains("?") ? "&" : "?") + "ticket=" + proxyTicket;
+        final String response = retrieveResponseFromServer(url, "UTF-8");
+        final String password = XmlUtils.getTextForElement(response, "credentials");
+
+
+        if (log.isTraceEnabled()) {
+            log.trace(String.format("ClearPass Response was:\n %s", response));
+        }
+
+        if (CommonUtils.isNotBlank(password)) {
+            return password;
+        }
+
+        log.error("Unable to Retrieve Password.  If you see a [403] HTTP response code returned from the CommonUtils then it most likely means the proxy configuration on the CAS server is not correct.\n\n"
+                + "Full Response from ClearPass was [" + response + "].");
+        return null;
+    }
+
+    /**
+     * Exists purely for testing purposes.
+     */
+    protected String retrieveResponseFromServer(final String url, final String encoding) {
+        return CommonUtils.getResponseFromServer(url, "UTF-8");
+    }
+
+
+    /**
+	 * Copied from {@link org.jasig.portal.security.provider.CacheSecurityContext}
+	 */
+	private class CacheOpaqueCredentials extends ChainingOpaqueCredentials implements NotSoOpaqueCredentials {
+
+		private static final long serialVersionUID = 1l;
+
+		public String getCredentials() {
+		  return this.credentialstring != null ? new String(this.credentialstring) : null;
+		}
+	}
+
+}

--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/cas/clearpass/PasswordCachingCasAssertionSecurityContextFactory.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/cas/clearpass/PasswordCachingCasAssertionSecurityContextFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.security.provider.cas.clearpass;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.apache.commons.io.IOUtils;
+import org.jasig.cas.client.util.CommonUtils;
+import org.jasig.portal.security.ISecurityContext;
+import org.jasig.portal.security.ISecurityContextFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+/**
+ * @author Scott Battaglia
+ */
+public final class PasswordCachingCasAssertionSecurityContextFactory implements ISecurityContextFactory {
+
+    private final static String DEFAULT_PORTAL_SECURITY_PROPERTY_FILE = "properties/security.properties";
+
+    private final static String CLEARPASS_CAS_URL_PROPERTY = PasswordCachingCasAssertionSecurityContextFactory.class.getName() + ".clearPassCasUrl";
+
+    private final String clearPassUrl;
+
+    public PasswordCachingCasAssertionSecurityContextFactory() {
+        final Resource resource = new ClassPathResource(DEFAULT_PORTAL_SECURITY_PROPERTY_FILE, getClass().getClassLoader());
+        final Properties securityProperties = new Properties();
+        InputStream inputStream = null;
+
+        try {
+            inputStream = resource.getInputStream();
+            securityProperties.load(inputStream);
+            this.clearPassUrl = securityProperties.getProperty(CLEARPASS_CAS_URL_PROPERTY);          
+        } catch (final Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            IOUtils.closeQuietly(inputStream);
+        }
+    }
+
+    public ISecurityContext getSecurityContext() {
+        if (CommonUtils.isNotBlank(this.clearPassUrl)) {
+            return new PasswordCachingCasAssertionSecurityContext(this.clearPassUrl);
+        }
+        
+        throw new IllegalStateException(String.format("clearPassUrl not configured.  Cannot create an instance of [%s] without it.", getClass().getSimpleName()));
+    }
+}

--- a/uportal-war/src/main/resources/properties/security.properties
+++ b/uportal-war/src/main/resources/properties/security.properties
@@ -35,7 +35,7 @@
 ## This is the factory that supplies the concrete authentication class
 root=org.jasig.portal.security.provider.UnionSecurityContextFactory
 root.cas=org.jasig.portal.security.provider.cas.CasAssertionSecurityContextFactory
-#root.cas=org.jasig.cas3.extensions.clearpass.integration.uportal.PasswordCachingCasAssertionSecurityContextFactory
+#root.cas=org.jasig.portal.security.provider.cas.clearpass.PasswordCachingCasAssertionSecurityContextFactory
 root.simple=org.jasig.portal.security.provider.SimpleSecurityContextFactory
 
 ## Answers what tokens are examined in the request for each context during authentication.
@@ -57,11 +57,8 @@ authorizationProvider=org.jasig.portal.security.provider.AuthorizationServiceFac
 ## this URL instead of the standard userName/password form.
 org.jasig.portal.channels.CLogin.CasLoginUrl=${environment.build.cas.protocol}://${environment.build.cas.server}/cas/login?service=${environment.build.uportal.protocol}://${environment.build.uportal.server}${environment.build.uportal.context}/Login
 
-## URL of the CAS cleartext password service
-#org.jasig.cas3.extensions.clearpass.integration.uportal.PasswordCachingCasAssertionSecurityContextFactory.clearPassCasUrl=${environment.build.cas.protocol}://${environment.build.cas.server}/cas/clearPass
-
-
-
+## URL of the CAS clearPass password service
+#org.jasig.portal.security.provider.cas.clearpass.PasswordCachingCasAssertionSecurityContextFactory.clearPassCasUrl==${environment.build.cas.protocol}://${environment.build.cas.server}/cas/clearPass
 
 ##
 ##  Local Only Authentication


### PR DESCRIPTION
CAS clearPass declares a dependency on old uPortal-impl to provide support for uPortal. Classes are to be moved back to the uPortal codebase and clearPass support cleaned up.
