### PR TITLE
Add MySQL 5 UTF-8 support

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/utils/MySQL5SpecificDBDialect.java
+++ b/uportal-war/src/main/java/org/jasig/portal/utils/MySQL5SpecificDBDialect.java
@@ -1,0 +1,12 @@
+package org.jasig.portal.utils;
+
+import org.hibernate.dialect.MySQL5InnoDBDialect;
+
+public class MySQL5SpecificDBDialect extends MySQL5InnoDBDialect {
+
+	public String getTableTypeString() {
+		return " ENGINE=InnoDB ROW_FORMAT=COMPRESSED";
+	}
+
+	
+}

--- a/uportal-war/src/main/java/org/jasig/portal/utils/PortalDialectResolver.java
+++ b/uportal-war/src/main/java/org/jasig/portal/utils/PortalDialectResolver.java
@@ -23,7 +23,6 @@ import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 
 import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.MySQL5InnoDBDialect;
 import org.hibernate.dialect.SQLServer2005Dialect;
 import org.hibernate.service.jdbc.dialect.internal.AbstractDialectResolver;
 
@@ -40,7 +39,7 @@ public class PortalDialectResolver extends AbstractDialectResolver {
         final int databaseMinorVersion = metaData.getDatabaseMinorVersion();
         
         if ("MySQL".equals(databaseName) && 5 == databaseMajorVersion) {
-            return new MySQL5InnoDBDialect();
+            return new MySQL5SpecificDBDialect();
         }
         
         if ("PostgreSQL".equals(databaseName) && 8 == databaseMajorVersion && databaseMinorVersion <= 1) {


### PR DESCRIPTION
First excuse me for my poor English.

As said in UP-3254 issue to avoid MySQL error (Specified key was too long; max key length is 767 bytes) when using UTF-8 for i18n support you have to use innodb_large_prefix MySQL Option (innodb_large_prefix=true in my.cnf).

Additionally you have to use some other options (innodb_file_format=barracuda and innodb_file_per_table=true).

But you also have to give informations at the end of the SQL create command : “ENGINE=InnoDB ROW_FORMAT=COMPRESSED”.

By default, hybernate MySQL5InnoDBDialect just add “ENGINE=InnoDB”.

In this commit I create a specific dialect which extends MySQL5InnoDBDialect to have “ENGINE=InnoDB ROW_FORMAT=COMPRESSED”
