### PR TITLE
UP-3624

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/url/RequireValidSessionFilter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/RequireValidSessionFilter.java
@@ -41,7 +41,7 @@ public class RequireValidSessionFilter extends OncePerRequestFilter {
     
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        final HttpSession session = request.getSession(false);
+        final HttpSession session = request.getSession(true);
         if (session != null && !session.isNew()) {
             //Session exists and is not new, don't bother filtering
             return true;


### PR DESCRIPTION
Making a slight change to RequiredValidSessionFilter so that a session is created if one does not exist. This is needed for the RemoteCookieCheckFilter to work properly, otherwise an initial page hit from a fresh browser always results in a false negative (cookies disabled).
