### PR TITLE
UP-3624

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/rest/RemoteCookieCheckController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rest/RemoteCookieCheckController.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.rest;
+
+import org.jasig.portal.utils.web.RemoteCookieCheckFilter;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * @author Chris Waymire <cwaymire@unicon.net>
+ */
+
+@Controller
+public class RemoteCookieCheckController {
+    public static final String COOKIE_CHECK_REQUEST_MAPPING = "/cookiecheck";
+
+    @RequestMapping(value=COOKIE_CHECK_REQUEST_MAPPING, method = RequestMethod.GET)
+    public ModelAndView verifyCookiesEnabled(HttpServletRequest request, HttpServletResponse response) throws ServletException,IOException {
+        final ModelAndView mv = new ModelAndView();
+
+        boolean cookieFound = false;
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equalsIgnoreCase(RemoteCookieCheckFilter.COOKIE_NAME)) {
+                    cookieFound = true;
+                    break;
+                }
+            }
+        }
+
+        if (cookieFound) {
+            String referer = (String)request.getSession().getAttribute(RemoteCookieCheckFilter.REFERER_ATTRIBUTE);
+            response.sendRedirect(referer);
+            return null;
+        } else {
+            return new ModelAndView("/jsp/PortletError/cookies");
+        }
+    }
+}

--- a/uportal-war/src/main/java/org/jasig/portal/utils/web/RemoteCookieCheckFilter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/utils/web/RemoteCookieCheckFilter.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portal.utils.web;
+
+/**
+ * @author Chris Waymire <cwaymire@unicon.net>
+ */
+import org.jasig.portal.rest.RemoteCookieCheckController;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class RemoteCookieCheckFilter implements Filter {
+    public static final String COOKIE_NAME = "JSESSIONID";
+    public static final String REFERER_ATTRIBUTE = "COOKIE_CHECK_REFERER";
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        if(!"POST".equals(httpServletRequest.getMethod())) {
+            boolean cookieFound = false;
+            Cookie[] cookies = httpServletRequest.getCookies();
+
+            if (cookies != null) {
+                for (Cookie cookie : cookies) {
+                    if (cookie.getName().equalsIgnoreCase(COOKIE_NAME)) {
+                        cookieFound = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!cookieFound) {
+                ((HttpServletRequest) request).getSession(true).setAttribute(REFERER_ATTRIBUTE,((HttpServletRequest) request).getRequestURI());
+                String url = ((HttpServletRequest) request).getContextPath() + "/api" + RemoteCookieCheckController.COOKIE_CHECK_REQUEST_MAPPING;
+                ((HttpServletResponse) response).sendRedirect(url);
+                return;
+            }
+        }
+
+        chain.doFilter(request,response);
+    }
+
+    @Override
+    public void destroy() {
+    }
+}

--- a/uportal-war/src/main/resources/properties/contexts/mvcContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/mvcContext.xml
@@ -32,6 +32,7 @@
     <bean id="requireValidSessionFilter" class="org.jasig.portal.url.RequireValidSessionFilter" />
     <bean id="urlCanonicalizingFilter" class="org.jasig.portal.url.UrlCanonicalizingFilter" />
     <bean id="createPortletCookieFilter" class="org.jasig.portal.utils.web.CreatePortletCookieFilter"/>
+    <bean id="remoteCookieCheckFilter" class="org.jasig.portal.utils.web.RemoteCookieCheckFilter"/>
     <bean id="multipartResolver"
         class="org.springframework.web.multipart.commons.CommonsMultipartResolver">
     

--- a/uportal-war/src/main/webapp/WEB-INF/jsp/PortletError/cookies.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/PortletError/cookies.jsp
@@ -1,0 +1,33 @@
+<%--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+--%>
+
+<%@ page isErrorPage="true" %>
+<% org.apache.commons.logging.Log logger = org.apache.commons.logging.LogFactory.getLog("org.jasig.portal.jsp.Error"); %>
+<html>
+<head>
+<title>Portal: An error has occured</title>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+</head>
+
+<body>
+<p><strong>Your browser doesn't accept cookies. Cookies are required to use this site.</strong></p>
+</body>
+</html>

--- a/uportal-war/src/main/webapp/WEB-INF/web.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/web.xml
@@ -176,7 +176,12 @@
         <filter-name>createPortletCookieFilter</filter-name>
         <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
     </filter>
-    
+
+    <filter>
+        <filter-name>remoteCookieCheckFilter</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
+    </filter>
+
     <!-- Useful for testing/debugging remote_user based authn 
     <filter>
         <filter-name>RemoteUserSettingFilter</filter-name>
@@ -269,6 +274,11 @@
 	 <filter-mapping>
         <filter-name>createPortletCookieFilter</filter-name>
         <servlet-name>RenderingDispatcherServlet</servlet-name>
+    </filter-mapping>
+
+    <filter-mapping>
+        <filter-name>remoteCookieCheckFilter</filter-name>
+        <url-pattern>/Login</url-pattern>
     </filter-mapping>
 
     <!-- Supports view rendering -->


### PR DESCRIPTION
Add a filter to the "/Login" URL pattern that will determine whether cookies are enabled on the remote browser. If cookies are not enabled then a redirect will be performed to the PortletError/cookies.jsp view with a message alerting the user that cookies are required.
