### PR TITLE
UP-3645

### DIFF
--- a/uportal-war/src/main/webapp/media/skins/universality/common/javascript/uportal/up-portlet-browser.js
+++ b/uportal-war/src/main/webapp/media/skins/universality/common/javascript/uportal/up-portlet-browser.js
@@ -202,7 +202,9 @@ var up = up || {};
 
         // initialize the view subcomponents
         that.categoryListView = fluid.initSubcomponent(that, "categoryListView", [container, that, fluid.COMPONENT_OPTIONS]);
-        that.stateListView = fluid.initSubcomponent(that, "stateListView", [container, that, fluid.COMPONENT_OPTIONS]);
+        if(that.options['stateListView'] != null) {
+            that.stateListView = fluid.initSubcomponent(that, "stateListView", [container, that, fluid.COMPONENT_OPTIONS]);
+        }
         that.searchView = fluid.initSubcomponent(that, "searchView", [container, that, fluid.COMPONENT_OPTIONS]);
         that.portletListView = fluid.initSubcomponent(that, "portletListView", [container, that, fluid.COMPONENT_OPTIONS]);
 


### PR DESCRIPTION
Modify up-portlet-browser to only initialize the "stateListView" subcomponent if the appropriate config option is present. This prevents a javascript failure from occuring in the event that a page uses the up-portlet-browser but does not define a stateListView.
