### PR TITLE
NOJIRA - Solve an issue on feature UP-3708

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/universality/components.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/components.xsl
@@ -494,7 +494,7 @@
   -->
   <xsl:template name="dlm.sidebar.links">
     <xsl:for-each select="/layout/sidebar/sidebarGroup">
-      <xsl:if test="count(//sidebarChannel) > 0">
+      <xsl:if test="count(./sidebarChannel) > 0">
         <div id="portalSidebarGroupLinks{position()}" class="fl-widget">
           <div class="fl-widget-inner">
             <div class="fl-widget-titlebar">


### PR DESCRIPTION
Solve issue on sidebar element shown, the sidebar group should be shown if there is an element in the current sidebargroup not if there is an element on all sidebargroups
