### PR TITLE
UP-3716:

### DIFF
--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -748,7 +748,7 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xmx512m -XX:MaxPermSize=512m</argLine>
+                    <argLine>-Xmx512m -XX:MaxPermSize=512m -Duser.timezone=UTC</argLine>
                     <systemPropertyVariables>
                         <org.jasig.portal.test>true</org.jasig.portal.test>
                     </systemPropertyVariables>


### PR DESCRIPTION
- Setting the user's timezone for testing to allow consistent results across java versions and build machine OS configurations.
- The tests started failing in Java 7u9 for both 32 and 64 bit JREs.
- The build machine OS's timezone setting appears to be throwing off the testing for only some build machines without this fix.
