### PR TITLE
UP-3719 Added adjustments to clean up some of the missing fluid styles.

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -196,6 +196,13 @@
     <xsl:otherwise>false</xsl:otherwise>
   </xsl:choose>
 </xsl:variable>
+<xsl:param name="USE_AJAX" select="'true'"/>
+<xsl:param name="JS_LIBRARY_SKIN">
+    <xsl:choose>
+      <xsl:when test="$USE_AJAX='true'">jqueryui</xsl:when>
+      <xsl:otherwise></xsl:otherwise>
+    </xsl:choose>
+</xsl:param>
 
 <!-- ****** PORTLET SETTINGS ****** -->
 <!--
@@ -244,6 +251,12 @@
     <!-- <link href="/uPortal/media/skins/respondr/uPortal4/css/temp.css" rel="stylesheet" type="text/css" /> -->
     <!-- <link href="/uPortal/media/skins/respondr/uPortal4/css/temp.css" rel="stylesheet" type="text/css" /> -->
     <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet" />
+</xsl:template>
+
+
+<xsl:template name="page.overrides">
+    <!-- <link href="/uPortal/media/skins/respondr/uPortal4/css/temp.css" rel="stylesheet" type="text/css" /> -->
+    <link href="/uPortal/media/skins/respondr/uPortal4/css/fluid_stopgap.css" rel="stylesheet" type="text/css" />
 </xsl:template>
 
 
@@ -429,7 +442,7 @@
  | Template contents can be any valid XSL or XHTML.
  -->
 <xsl:template match="/">
-    <html lang="{$USER_LANG}">
+    <html lang="{$USER_LANG}" class="respondr">
         <head>
             <xsl:call-template name="page.title" />
             <xsl:call-template name="page.meta" />
@@ -442,8 +455,10 @@
             <xsl:call-template name="page.js" />
 
             <xsl:call-template name="page.temp" />
+
+            <xsl:call-template name="page.overrides" />
         </head>
-        <body class="up dashboard portal">
+        <body class="up dashboard portal fl-theme-mist">
 
             <div id="wrapper">
                 <header class="portal-header" role="banner">

--- a/uportal-war/src/main/resources/layout/theme/universality/page.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/page.xsl
@@ -83,7 +83,7 @@
       </xsl:choose>
     </xsl:variable>
 
-    <html lang="{$USER_LANG}">
+    <html lang="{$USER_LANG}" class="universality">
       <head>
         <title>
           <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->

--- a/uportal-war/src/main/webapp/media/skins/respondr/uPortal4/less/fluid_stopgap.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/uPortal4/less/fluid_stopgap.less
@@ -1,0 +1,89 @@
+/*.fl-theme-mist .email-portlet-table a {
+font-weight: normal;
+}*/
+.fl-theme-mist a{color:#5a95cf;}
+
+.fl-widget .fl-widget-content {
+	zoom: 1;
+}
+
+.portlet .flc-pager-top {
+margin-bottom: .5em;
+}
+.portlet .fl-pager .fl-pager-ui li {
+list-style-type: none;
+display: inline-block;
+}
+.flc-pager-links a {
+vertical-align: middle;
+}
+
+.email-list .flc-pager-links .flc-pager-pageLink a {
+text-decoration: underline;
+color: #5A95CF;
+}
+
+
+
+.portlet .fl-pager .fl-pager-ui li{
+	list-style-type:none;
+	display:inline-block
+}
+.fl-pager caption{
+	padding:.63em 0;
+	margin-bottom:0
+}
+.fl-pager th{
+	cursor:pointer
+}
+.fl-pager-controls {
+	padding:.69em .69em
+}
+.flc-pager-links a{
+	vertical-align:middle
+}
+
+.portlet .flc-pager-page-size, #allFolders {
+
+	margin-top: 10px;
+}
+.portlet .flc-pager-page-size {
+	width: 60px;
+}
+#allFolders {
+	width: 150px;
+}
+
+.fl-theme-mist th {
+border: .1em solid #5a95cf;
+background-color: #dfefff;
+}
+.up table, .up table th, .up table td {
+border: none!important;
+}
+
+.fl-col-side.fl-force-left.span4 {
+	margin-left: 0;
+}
+
+.fl-col-flex2 .fl-col {
+	width: 48.85%;
+	margin-left: .25%;
+	margin-right: .25%;
+	padding-left: .25%;
+	padding-right: .25%;
+}
+.fl-col-flex2, .fl-col-flex3, .fl-col-flex4, .fl-col-flex5 {
+	overflow: auto;
+	zoom: 1;
+}
+.fl-col {
+	float: left;
+	display: inline;
+}
+
+@media (max-width: 979px) {
+	[class*="span"].pull-right, .row-fluid [class*="span"].pull-right {
+		float: none;
+	}
+}

--- a/uportal-war/src/main/webapp/media/skins/respondr/uPortal4/skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/respondr/uPortal4/skin.xml
@@ -26,6 +26,10 @@
 
   <css>http://fonts.googleapis.com/css?family=Oxygen</css>
 
+  <!-- Default jQuery UI theme.  Point this to a custom jQuery UI theme if desired. -->
+  <css included="plain">/ResourceServingWebapp/rs/jqueryui/1.8.13/theme/smoothness/jquery-ui-1.8.13-smoothness.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/jqueryui/1.8.13/theme/smoothness/jquery-ui-1.8.13-smoothness.min.css</css>
+
   <css included="plain">/ResourceServingWebapp/rs/normalize/2.1.2/normalize-2.1.2.css</css>
   <css included="aggregated">/ResourceServingWebapp/rs/normalize/2.1.2/normalize-2.1.2.min.css</css>
 


### PR DESCRIPTION
Also added a "stopgap" css file as a temporary container for housing fluid styles within the responder theme.

Added "responder" & "universality" classes to the HTML as hooks for making it easier to over-ride styles in the various themes.

Included the jQueryUI css into the responder theme
