### PR TITLE
UP-3897 : Change mobile profile back to mobile skin, create respondr pro...

### DIFF
--- a/uportal-war/src/main/data/default_entities/profile/defaultTemplateUser_mobileDefault.profile.xml
+++ b/uportal-war/src/main/data/default_entities/profile/defaultTemplateUser_mobileDefault.profile.xml
@@ -23,6 +23,6 @@
   <name>HTML mobile browser profile</name>
   <fname>mobileDefault</fname>
   <description>A sample mobile profile for common web browsers</description>
-  <structure name="DLMTabsColumns"/>
-  <theme name="Respondr"/>
+  <structure name="DLMMobileColumns"/>
+  <theme name="UniversalityMobile"/>
 </profile>

--- a/uportal-war/src/main/data/default_entities/profile/defaultTemplateUser_respondr.profile.xml
+++ b/uportal-war/src/main/data/default_entities/profile/defaultTemplateUser_respondr.profile.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile script="classpath://org/jasig/portal/io/import-profile_v3-2.crn" username="defaultTemplateUser">
+  <name>HTML responsive design profile</name>
+  <fname>respondr</fname>
+  <description>A sample responsive profile for common web browsers</description>
+  <structure name="DLMTabsColumns"/>
+  <theme name="Respondr"/>
+</profile>

--- a/uportal-war/src/main/data/default_entities/profile/system_mobileDefault.profile.xml
+++ b/uportal-war/src/main/data/default_entities/profile/system_mobileDefault.profile.xml
@@ -23,6 +23,6 @@
   <name>HTML mobile browser profile</name>
   <fname>mobileDefault</fname>
   <description>A sample mobile profile for common web browsers</description>
-  <structure name="DLMTabsColumns"/>
-  <theme name="Respondr"/>
+  <structure name="DLMMobileColumns"/>
+  <theme name="UniversalityMobile"/>
 </profile>

--- a/uportal-war/src/main/data/default_entities/profile/system_respondr.profile.xml
+++ b/uportal-war/src/main/data/default_entities/profile/system_respondr.profile.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile script="classpath://org/jasig/portal/io/import-profile_v3-2.crn" username="system">
+  <name>HTML responsive design profile</name>
+  <fname>respondr</fname>
+  <description>A responsive profile for common web browsers</description>
+  <structure name="DLMTabsColumns"/>
+  <theme name="Respondr"/>
+</profile>

--- a/uportal-war/src/main/resources/properties/contexts/userContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/userContext.xml
@@ -46,6 +46,7 @@
     <util:map id="profileKeyMappings">
         <entry key="desktop" value="default"/>
         <entry key="mobile" value="mobileDefault"/>
+        <entry key="respondr" value="respondr" />
     </util:map>
 
     <bean id="profileMapper" class="org.jasig.portal.layout.ChainingProfileMapperImpl">

--- a/uportal-war/src/main/webapp/WEB-INF/flows/local-login/loginForm.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/local-login/loginForm.jsp
@@ -67,6 +67,7 @@
             <select id="${n}profile" name="profile">
                 <option value="desktop" ${ profile == 'desktop' ? 'selected=selected' : '' }>Desktop</option>
                 <option value="mobile" ${ profile == 'mobile' ? 'selected=selected' : '' }>Mobile</option>
+                <option value="respondr" ${ profile == 'respondr' ? 'selected=selected' : '' }>Responsive</option>
             </select>
         
             <div class="buttons utilities">


### PR DESCRIPTION
...file.

This will change the mobile login back to mobile and add a new profile called "respondr". If you are using the built in cas, then just change the redirect link from :
http://localhost:8080/cas/login?service=http://localhost:8080/uPortal/Login
to:
http://localhost:8080/cas/login?service=http://localhost:8080/uPortal/Login?profile=respondr

and it will utilize the respondr profile.

If you are using the login form then there is a responsive option.
