### PR TITLE
add IntelliJ-IDE-generated overlay directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /assembly/.ant-targets-build.xml
 *.iml
 /.idea
+uportal-portlets-overlay/*/overlays


### PR DESCRIPTION
IntelliJ IDE can helpfully generate directories reflecting the overlaid-upon .war files.
These directories should not be committed to source control (being generated from source) and this commit enhances `.gitignore` to help developers to properly ignore these directories in interacting with source control.
