### PR TITLE
Removed Font Awesome CDN reference, and instead adding reference to Font...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
         <pluto.version>2.1.0-M3</pluto.version>
         <portlet-api.version>2.0</portlet-api.version>
         <quartz.version>1.8.4</quartz.version>
-        <resource-server.version>1.0.34-M3</resource-server.version>
+        <resource-server.version>1.0.34</resource-server.version>
         <servlet-api.version>3.0.1</servlet-api.version>
         <slf4j.version>1.7.4</slf4j.version>
         <spring-framework.version>3.1.4.RELEASE</spring-framework.version>

--- a/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -200,7 +200,7 @@
     <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
       <nav class="portal-nav">
         <div class="container">
-        <a href="#" class="menu-toggle"><i class="icon-align-justify"></i> Menu</a>
+        <a href="#" class="menu-toggle"><i class="fa fa-align-justify"></i> Menu</a>
         <div id="portalNavigation" class="fl-widget">
           <div id="portalNavigationInner" class="fl-widget-inner header">
               <ul id="portalNavigationList" class="menu fl-tabs flc-reorderer-column">
@@ -211,7 +211,7 @@
                     <li class="portal-navigation-add-item">
                         <a href="javascript:;" title="{upMsg:getMessage('add.tab', $USER_LANG)}" class="portal-navigation-add">
                           <!-- <xsl:value-of select="upMsg:getMessage('add.tab', $USER_LANG)"/> -->
-                          <i class="icon-plus-sign"></i>
+                          <i class="fa fa-plus-sign-circle"></i>
                         </a>
                     </li>
                  </xsl:if>
@@ -330,7 +330,7 @@
         <span title="{$NAV_INLINE_EDIT_TITLE}" class="portal-navigation-label {$NAV_INLINE_EDIT_TEXT}">
           <xsl:value-of select="upElemTitle:getTitle(@ID, $USER_LANG, @name)"/>
         </span>
-        <i class="icon-chevron-right"></i>
+        <i class="fa fa-chevron-right"></i>
       </a>
       <xsl:if test="$AUTHENTICATED='true' and @activeTab='true' and $NAV_POSITION != 'single' and not($PORTAL_VIEW='focused')">
         <xsl:if test="not(@dlm:deleteAllowed='false')">

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -247,14 +247,6 @@
 </xsl:template>
 <!-- ========================================================================= -->
 
-
-<xsl:template name="page.temp">
-    <!-- <link href="/uPortal/media/skins/respondr/uPortal4/css/temp.css" rel="stylesheet" type="text/css" /> -->
-    <!-- <link href="/uPortal/media/skins/respondr/uPortal4/css/temp.css" rel="stylesheet" type="text/css" /> -->
-    <link href="//netdna.bootstrapcdn.com/font-awesome/3.2.1/css/font-awesome.css" rel="stylesheet" />
-</xsl:template>
-
-
 <xsl:template name="page.overrides">
     <link href="/uPortal/media/skins/respondr/uPortal4/css/fluid_stopgap.css" rel="stylesheet" type="text/css" />
     <link href="/uPortal/media/skins/respondr/uPortal4/css/layout-portal.css" rel="stylesheet" type="text/css" />
@@ -529,7 +521,6 @@
                 <link rel="shortcut icon" href="{$PORTAL_SHORTCUT_ICON}" type="image/x-icon" />
             </xsl:if>
             <xsl:call-template name="page.js" />
-            <xsl:call-template name="page.temp" />
             <xsl:call-template name="page.overrides" />
         </head>
         <body class="up dashboard portal fl-theme-mist">

--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Search/searchLauncher.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Search/searchLauncher.jsp
@@ -16,7 +16,7 @@
             <input id="${n}webSearchInput"  class="searchInput input-large search-query form-control" value="" name="query" type="text" placeholder="Enter search terms"/>
             <span class="input-group-btn">
               <button id="webSearchSubmit" type="submit" name="submit" class="btn btn-default" value="${searchLabel}">
-                <span>${searchLabel}</span><i class="icon icon-search"></i></button>
+                <span>${searchLabel}</span><i class="fa fa-search"></i></button>
             </span>
           </div>
             <input class="autocompleteUrl" name="autocompleteUrl" type="hidden" value="${autocompleteUrl}"/>

--- a/uportal-war/src/main/webapp/media/skins/respondr/uPortal4/less/styles.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/uPortal4/less/styles.less
@@ -259,7 +259,7 @@ body {
                     text-decoration: none;
                     padding: 8px 14px;
 
-                    i.icon-chevron-right {
+                    i {
                         float: right;
                         margin-top: 2px;
                         margin-right: -6px;
@@ -513,7 +513,7 @@ body {
             display: none;
         }
 
-        i.icon-chevron-right {
+        i {
             display: none;
         }
 

--- a/uportal-war/src/main/webapp/media/skins/respondr/uPortal4/skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/respondr/uPortal4/skin.xml
@@ -28,13 +28,18 @@
 
   <css included="plain">/ResourceServingWebapp/rs/normalize/2.1.2/normalize-2.1.2.css</css>
   <css included="aggregated">/ResourceServingWebapp/rs/normalize/2.1.2/normalize-2.1.2.min.css</css>
-
+  
+  <css included="plain">/ResourceServingWebapp/rs/fontawesome/4.0.3/css/font-awesome.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/fontawesome/4.0.3/css/font-awesome.min.css</css>
+  
   <css included="plain">/ResourceServingWebapp/rs/bootstrap/3.0.0/css/bootstrap-3.0.0.css</css>
   <css included="aggregated">/ResourceServingWebapp/rs/bootstrap/3.0.0/css/bootstrap-3.0.0.min.css</css>
 
     <!-- Default jQuery UI theme.  Point this to a custom jQuery UI theme if desired. -->
     <css included="plain">/ResourceServingWebapp/rs/jqueryui/1.10.3/theme/smoothness/jquery-ui-1.10.3.css</css>
     <css included="aggregated">/ResourceServingWebapp/rs/jqueryui/1.10.3/theme/smoothness/jquery-ui-1.10.3.min.css</css>
+
+  
 
     <css>css/styles.css</css>
 


### PR DESCRIPTION
... Awesome v4 via ResourceServer

Changed the icons to use Font Awesome icons instead of Bootstrap’s Glyphicons.  The Font Awesome icons are cleaner.

Also updated the .less file to remove specific icon references for small views.
