### PR TITLE
UP-3307: Leveraging unload function to fix back when page is returned to via the back button

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/permissions-administration/listOwners.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/permissions-administration/listOwners.jsp
@@ -155,7 +155,17 @@ up.jQuery(function() {
     var $ = up.jQuery;
 
     $(document).ready(function(){
+        setupPermissionsListOwnersLoadVariables();
+    });
+    
+});
 
+// Unload is being leveraged to reset back to fresh state when the back button is pushed
+$(window).unload( function () {
+    setupPermissionsListOwnersLoadVariables();
+});
+
+function setupPermissionsListOwnersLoadVariables() {
         var submitForm = function(form){
             if (!principalSuggest.getValue() || !permissionSuggest.getValue()) {
                 alert('<spring:message code="please.choose.principal.and.permission.from.the.autocomplete.menus" htmlEscape="false" javaScriptEscape="true"/>');
@@ -228,8 +238,5 @@ up.jQuery(function() {
                 return false;
             }
         });
-    });
-    
-});
+};
 </script>
-


### PR DESCRIPTION
Leveraging unload function to reset the page back to a fresh state if the back button is pressed, by running same javascript as ready.  Refactored the script into its own function to avoid dup code.
