### PR TITLE
Normalize theme name “Respondr” in PAGS group name

### DIFF
--- a/uportal-war/src/main/data/quickstart_entities/fragment-definition/authenticated.respondr-lo.fragment-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-definition/authenticated.respondr-lo.fragment-definition.xml
@@ -24,7 +24,7 @@
     <dlm:audience evaluatorFactory="org.jasig.portal.layout.dlm.providers.GroupMembershipEvaluatorFactory">
       <paren mode="AND">
         <attribute mode="deepMemberOf" name="Authenticated Users"/>
-        <attribute mode="deepMemberOf" name="Responder Theme Users"/>
+        <attribute mode="deepMemberOf" name="Respondr Theme Users"/>
       </paren>
     </dlm:audience>
   </dlm:fragment>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-definition/guest.respondr-lo.fragment-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-definition/guest.respondr-lo.fragment-definition.xml
@@ -26,7 +26,7 @@
         <paren mode="NOT">
           <attribute mode="deepMemberOf" name="Authenticated Users"/>
         </paren>
-        <attribute mode="deepMemberOf" name="Responder Theme Users"/>
+        <attribute mode="deepMemberOf" name="Respondr Theme Users"/>
       </paren>
     </dlm:audience>
   </dlm:fragment>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-definition/respondr-lo.fragment-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-definition/respondr-lo.fragment-definition.xml
@@ -23,7 +23,7 @@
   <dlm:fragment name="Respondr" ownerID="respondr-lo" precedence="80">
     <dlm:audience evaluatorFactory="org.jasig.portal.layout.dlm.providers.GroupMembershipEvaluatorFactory">
       <paren mode="OR">
-        <attribute mode="deepMemberOf" name="Responder Theme Users"/>
+        <attribute mode="deepMemberOf" name="Respondr Theme Users"/>
       </paren>
     </dlm:audience>
   </dlm:fragment>

--- a/uportal-war/src/main/resources/properties/groups/PAGSGroupStoreConfig.xml
+++ b/uportal-war/src/main/resources/properties/groups/PAGSGroupStoreConfig.xml
@@ -63,7 +63,7 @@
       <member-key>authenticated_users</member-key>
       <member-key>desktop_device_access</member-key>
       <member-key>mobile_device_access</member-key>
-      <member-key>responder_theme_users</member-key>
+      <member-key>respondr_theme_users</member-key>
     </members>
   </group>
 
@@ -134,8 +134,8 @@
   </group>
 
   <group>
-    <group-key>responder_theme_users</group-key>
-    <group-name>Responder Theme Users</group-name>
+    <group-key>respondr_theme_users</group-key>
+    <group-name>Respondr Theme Users</group-name>
     <group-description>User Access by Theme</group-description>
     <selection-test>
       <test-group>


### PR DESCRIPTION
Name the PAGS group of users of the Respondr theme “Respondr Theme Users” rather than “Responder Theme Users”.

This bit me in testing in that I searched Groups for "Respondr", found nothing, and wrongly concluded that something was wrong with the loading of the group representing users of the Respondr theme, whereas all that was really at work was a difference in spelling of "Respondr".  I believe "Respondr" is the preferred spelling, standardizing on that.
