### PR TITLE
.travis.yml workaround allowing Travis-CI build to run.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: java
+before_install:
+  - unset GEM_PATH

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ For more detailed help please refer to the [uPortal Manual](https://wiki.jasig.o
 Additional information about uPortal is available on the [uPortal Home Page](http://www.jasig.org/uportal)
 or in the [uPortal Wiki](https://wiki.jasig.org/display/UPC/Home)
 
+## Travis-CI Continuous Integration
+
+uPortal uses Travis-CI for lightweight continuous integration.  You can see build statuses at [https://travis-ci.org/Jasig/uPortal].  This handy image summarizes build status for the master branch:
+
+[![Master Branch Build Status](https://travis-ci.org/Jasig/uPortal.png?branch=master)](https://travis-ci.org/Jasig/uPortal)
+
 ## Requirements
 * JDK 1.6.0_26 or later - Just a JRE is not sufficient, a full JDK is required
 * Servlet 2.5 Container - Tomcat 6.0 is recommended, there some configuration changes that must be made for Tomcat 6.0 which are documented in the [uPortal manual](https://wiki.jasig.org/display/UPM40/Installing+Tomcat).


### PR DESCRIPTION
Un-sets `GEM_PATH` in `before_install` phase of Travis build configuration.  This does not affect builds outside of Travis.

The `.travis.yml` customization can be retired once uPortal is pulling in a fixed version of the SASS Maven compile plugin, presumably the forthcoming version `1.1.2`.

The `README.md` image will of course only make sense once this pull is merged to `master` and Travis-CI continuous integration is turned back on.

See [https://travis-ci.org/apetro/uPortal/builds/18151771](successful build of apetro/master containing this .travis.yml change) for demonstration that the proposed `.travis.yml` results in a working Travis-CI build.
