### PR TITLE
add Travis IRC configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,8 @@ language: java
 before_install:
   - unset GEM_PATH
 notifications:
-  irc: "chat.freenode.net#jasig-uportal"
+  irc: 
+    channels: 
+    - "chat.freenode.net#jasig-uportal"
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
Configures Travis-CI to post to `#jasig-uportal` IRC chat on build success and failure.

This may end up feeling too noisy and we might want to back off on it via configuration documented at http://docs.travis-ci.com/user/notifications/#IRC-notification .
