### PR TITLE
Adds links to mktplce entry page for Go buttons

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/entry.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/entry.jsp
@@ -78,13 +78,13 @@
 			<div class="col-md-3 col-xs-6 marketplace_portlet_title">${Portlet.title}</div>
 			<div class="col-md-3 col-xs-6 col-md-push-3" class="${n}go_button">
 				<div class="btn-group marketplace_button_group" style="float:right">
-					<button type="button" class="btn btn-default marketplace_dropdown_button">Go</button>
+					<a href="${renderRequest.contextPath}/p/${Portlet.FName}/render.uP" id="marketplace_go_button" class="btn btn-default marketplace_dropdown_button">Go</a>
 					<button type="button" class="btn btn-default dropdown-toggle marketplace_dropdown_button" data-toggle="dropdown">
 						<span class="caret"></span>
 						<span class="sr-only"></span>
 					</button>
 					<ul class="dropdown-menu marketplace_dropdown_menu" role="menu">
-						<li><a href="#">Go</a></li>
+						<li><a href="${renderRequest.contextPath}/p/${Portlet.FName}/render.uP">Go</a></li>
 						<li><a href="#">Add to Favorites</a></li>
 						<li class="divider"></li>
 						<li><a href="#">Share on Twitter</a></li>


### PR DESCRIPTION
The go buttons allow the user to use the portlets without
having to add the portlet to their layout.

With the note that in Jasig Jira, an issue needs to be created to make this more configurable. A java/spring message bundle perhaps, because I think that most configurators will not need two links to the exact same place that close to each other on a page. The go name might not be everyone's cup of tea. Sharing on facebook and twitter might be overkill for some people.

https://issues.jasig.org/browse/UP-3966
