### PR TITLE
UP-3947: Changing group of personalization gallery from Guests to Authenticated Users

### DIFF
--- a/uportal-war/src/main/data/default_entities/portlet-definition/personalization-gallery.portlet-definition.xml
+++ b/uportal-war/src/main/data/default_entities/portlet-definition/personalization-gallery.portlet-definition.xml
@@ -30,7 +30,7 @@
         <ns2:isFramework>true</ns2:isFramework>
         <ns2:portletName>JspInvoker</ns2:portletName>
     </portlet-descriptor>
-    <group>Guests</group>
+    <group>Authenticated Users</group>
     <parameter>
         <name>disableDynamicTitle</name>
         <value>true</value>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-3947

UP-3947: Changing group of personalization gallery from Guests to Authenticated Users to fix non-admin user issues with moving, deleting and panes console error
