### PR TITLE
UP-3997: Adjusting the rows margins to fit within the tabs box.

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
@@ -57,6 +57,10 @@
 #${n}permissionBrowser .dataTables-right {
     float:right;
 }
+#${n}permissionBrowser .row {
+    margin-left:0px;
+    margin-right:0px;
+}
 </style>
 <!--
 PORTLET DEVELOPMENT STANDARDS AND GUIDELINES

--- a/uportal-war/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
@@ -70,6 +70,10 @@
 #${n}permissionBrowser .dataTables-right {
     float:right;
 }
+#${n}permissionBrowser .row {
+    margin-left:0px;
+    margin-right:0px;
+}
 </style>
 <!--
 PORTLET DEVELOPMENT STANDARDS AND GUIDELINES


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-3997

The bootstrap and default csses had the margins at -15px for right and left causing the datatables to spill outside of the box.
