### PR TITLE
UP-3988: Update group and user permissions tabs to work with fluid 1.5 and jQuery ui 1.10

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
@@ -280,5 +280,6 @@ up.jQuery(function() {
 
     initializeTable('principal');
     initializeTable('target');
+    $("#${n}assignmentTabs").tabs({ active: 0 });
 });
 </script>

--- a/uportal-war/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
@@ -278,7 +278,7 @@ up.jQuery(function() {
 
     initializeTable('principal');
     initializeTable('target');
-
+    $("#${n}assignmentTabs").tabs({ active: 0 });
 });
 </script>
 


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-3988

Readding the .tabs call with the newer jQuery 1.10 parameter(active instead of selected)
