### PR TITLE
Maximizing a portlet supersedes focusing on a fragment.

### DIFF
--- a/uportal-war/src/main/resources/layout/structure/columns/columns.xsl
+++ b/uportal-war/src/main/resources/layout/structure/columns/columns.xsl
@@ -56,10 +56,15 @@
 
 
     <xsl:variable name="focusedFragmentId">
-        <!-- if the focusedTabID is the id of a non-regular folder, then that ID is the focusedFragmentID,
+        <!-- If the user is *not* focusing on a particular portlet,
+        and the user is *not* focusing on a regular-type tab,
+        and if the focusedTabID is the id of a non-regular folder,
+        then that ID is the focusedFragmentID,
          otherwise none -->
         <xsl:choose>
-            <xsl:when test="$focusedTabID!='none' and /layout/folder/folder[@ID=$focusedTabID and @type!='regular']">
+            <xsl:when test="not(//folder/channel[@ID = $userLayoutRoot])
+                            and $focusedTabID!='none'
+                            and /layout/folder/folder[@ID=$focusedTabID and @type!='regular']">
                 <xsl:value-of select="/layout/folder/folder[@ID=$focusedTabID and @type!='regular']/@ID"/>
             </xsl:when>
             <xsl:otherwise>none</xsl:otherwise>


### PR DESCRIPTION
Fixes problem where the focus-on-a-fragment feature had broken maximizing portlet when portlet is a favorite or member of a favorite collection.

Without this fix:
1. View a collection of favorites, by clicking its name from the Favorites portlet.
2. Maximize a portlet, via e.g. the Options menu available from its title bar.
3. Observe failure to focus the portlet.  Sad panda.

![fail_to_maximize_announcements_on_news_collection](https://f.cloud.github.com/assets/952283/2350895/3f392dfe-a576-11e3-8f45-d77b04a6780a.png)

With this fix:
1. View a collection of favorites, by clicking its name from the Favorites portlet.
2. Maximize a portlet, via e.g. the Options menu available from its title bar.
3. Observe focus on the maximized portlet.  Happy badger.

![success_focus_announcements_in_news_fragment](https://f.cloud.github.com/assets/952283/2350963/fcc7bdb8-a576-11e3-90e9-c9daa385803f.png)
