### PR TITLE
UP-4006: Fixing the assumption that the first profile created is default.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/dlm/RDBMDistributedLayoutStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/dlm/RDBMDistributedLayoutStore.java
@@ -88,8 +88,6 @@ import org.jasig.portal.utils.Tuple;
 import org.jasig.portal.xml.XmlUtilities;
 import org.jasig.portal.xml.XmlUtilitiesImpl;
 import org.jasig.portal.xml.xpath.XPathOperations;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -119,7 +117,7 @@ import com.google.common.cache.Cache;
  */
 public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
     public static final String RCS_ID = "@(#) $Header$";
-    protected final Logger logger = LoggerFactory.getLogger(RDBMDistributedLayoutStore.class);
+
     private static final Pattern VALID_PATHREF_PATTERN = Pattern.compile(".+\\:/.+");
     private static final String BAD_PATHREF_MESSAGE = "## DLM: ORPHANED DATA ##";
 

--- a/uportal-war/src/main/java/org/jasig/portal/layout/simple/RDBMUserLayoutStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/simple/RDBMUserLayoutStore.java
@@ -97,7 +97,7 @@ import com.google.common.cache.Cache;
  */
 public abstract class RDBMUserLayoutStore implements IUserLayoutStore, InitializingBean {
 
-    protected final Logger logger = LoggerFactory.getLogger(RDBMUserLayoutStore.class);
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
     private static String PROFILE_TABLE = "UP_USER_PROFILE";
 
     protected static final String DEFAULT_LAYOUT_FNAME = "default";


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4006

Fixing the assumption that the first profile created is default.  Any profile can now be created without the layout changing or being clobbered when switching.

There was an assumption that a profile named "default" was the first to be created.  With respondr this is not a correct assumption.  On login, if the default profile wasn't detected the layout for the user's current profile was set to 0(zero used to indicate a profile hasn't had a layout initialized).  This resetting of the layout_id to 0 due to the default profile not being created was not correct.  The layout that was created when respondr or defaultMobile is as valid as a default profile's layout.

Upon creation of a user profile, the layout_id for the new profile is set to 0.  This is valid only if another profile has not been created and layout initialized.  If there is another profile that has a saved layout(will always have a layout_id of non-zero), then the layout_id for the new profile should match the existing one to leverage it.  The user profiles will share the same layout, when a layout has been created and switching profiles should not change the layout for the user.
