### PR TITLE
UP-4011, UP-4012: Adding respondr theme skin and gallery as hidden to the -lo.templates

### DIFF
--- a/uportal-war/src/main/data/default_entities/layout/fragmentTemplate.layout.xml
+++ b/uportal-war/src/main/data/default_entities/layout/fragmentTemplate.layout.xml
@@ -25,6 +25,12 @@
     <folder hidden="true" immutable="true" name="Header folder" type="header" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false"/>
     </folder>
-    <folder hidden="false" immutable="false" name="Footer folder" type="footer" unremovable="false"/>
+    <folder hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false"/>
+    </folder>
+    <folder hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false"/>
+    </folder>
+    <folder hidden="true" immutable="false" name="Footer folder" type="footer" unremovable="false"/>
   </folder>
 </layout>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/academics-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/academics-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+    </folder>
     <folder ID="s5" hidden="false" immutable="false" name="Academics" type="regular" unremovable="false">
       <folder ID="s6" hidden="false" immutable="false" name="Column 1" type="regular" unremovable="false">
         <structure-attribute>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/admin-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/admin-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+    </folder>
     <folder ID="s7" hidden="false" immutable="false" name="Admin Tools" type="regular" unremovable="false">
       <structure-attribute>
           <name>externalId</name>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/all-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/all-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+    </folder>
     <folder ID="s4" hidden="false" immutable="true" name="Header Bottom folder" type="header-bottom" unremovable="true">
       <channel fname="emergency-alert" unremovable="false" hidden="false" immutable="false" ID="n5"/>
     </folder>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/authenticated-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/authenticated-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+    </folder>
     <folder ID="s4" hidden="false" immutable="true" name="Header Right folder" type="header-right" unremovable="true">
       <channel fname="search-launcher" unremovable="false" hidden="false" immutable="false" ID="n5"/>
     </folder>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/authenticated.respondr-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/authenticated.respondr-lo.fragment-layout.xml
@@ -25,6 +25,9 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
     <folder ID="s4" hidden="false" immutable="true" name="Pre Header folder" type="pre-header" unremovable="true">
       <channel fname="notification-icon" unremovable="false" hidden="false" immutable="false" ID="n5"/>
       <channel fname="portal-greeting" unremovable="false" hidden="false" immutable="false" ID="n6"/>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/campus-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/campus-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+    </folder>
     <folder ID="s5" hidden="false" immutable="false" name="Campus" type="regular" unremovable="false">
       <structure-attribute>
           <name>externalId</name>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/developer-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/developer-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
         <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
             <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
         </folder>
+        <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+            <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+        </folder>
+        <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+            <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+        </folder>
         <folder ID="s5" hidden="false" immutable="false" name="Development" type="regular" unremovable="false">
             <structure-attribute>
                 <name>externalId</name>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/ent-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/ent-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+    </folder>
     <folder ID="s5" hidden="false" immutable="false" name="Entertainment" type="regular" unremovable="false">
       <structure-attribute>
           <name>externalId</name>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/guest-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/guest-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+    </folder>
     <folder ID="s4" hidden="false" immutable="false" name="Welcome" type="regular" unremovable="false">
       <structure-attribute>
           <name>externalId</name>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/guest.respondr-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/guest.respondr-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s20" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n21"/>
+    </folder>
     <folder ID="s4" hidden="false" immutable="true" name="Pre Header folder" type="pre-header" unremovable="true">
       <channel fname="login-launcher" unremovable="false" hidden="false" immutable="false" ID="n19"/>
     </folder>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/news-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/news-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+    </folder>
     <folder ID="s5" hidden="false" immutable="false" name="News" type="regular" unremovable="false">
       <structure-attribute>
           <name>externalId</name>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/respondr-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/respondr-lo.fragment-layout.xml
@@ -25,8 +25,11 @@
     <folder ID="s2" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
-    <folder ID="s4" hidden="false" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
-        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n5"/>
+    <folder ID="s17" hidden="false" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
     </folder>
     <folder ID="s6" hidden="false" immutable="true" name="Header Left folder" type="header-left" unremovable="true">
       <channel fname="portal-logo" unremovable="false" hidden="false" immutable="false" ID="n7"/>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/staff-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/staff-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
         <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
             <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
         </folder>
+        <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+            <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+        </folder>
+        <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+            <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+        </folder>
         <folder ID="s5" hidden="false" immutable="false" name="Main Staff Tab" type="regular" unremovable="false">
             <structure-attribute>
                 <name>externalId</name>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/welcome-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/welcome-lo.fragment-layout.xml
@@ -25,6 +25,12 @@
     <folder ID="s2" hidden="true" immutable="true" name="Header folder" type="page-top" unremovable="true">
       <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n3"/>
     </folder>
+    <folder ID="s17" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+        <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n18"/>
+    </folder>
+    <folder ID="s19" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n20"/>
+    </folder>
     <folder ID="s5" dlm:deleteAllowed="false" dlm:editAllowed="false" dlm:moveAllowed="false" hidden="false" immutable="false" name="Welcome" type="regular" unremovable="false">
       <structure-attribute>
           <name>externalId</name>

--- a/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
@@ -312,6 +312,7 @@
                 </xsl:if>
             </ul>
             <script type="text/javascript">
+                $ = up.jQuery;
                 up.jQuery(document).ready(function() {
                     $('section.<xsl:value-of select="@fname" />').hover(function() {
                         $(this).find('.hover-chrome').stop(true, true).slideDown('medium');

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -517,6 +517,7 @@
                 }
             });
             </xsl:if>
+            <xsl:if test="$AUTHENTICATED='true'">
             var layoutPreferences = up.LayoutPreferences("body", {
                 tabContext: '<xsl:value-of select="$TAB_CONTEXT"/>',
                 numberOfPortlets: '<xsl:value-of select="count(content/column/channel)"/>',
@@ -553,6 +554,7 @@
         if(layoutPreferences.components.gallery) {
             layoutPreferences.components.gallery.openGallery();
         }
+    </xsl:if>
     });
     </script>
 


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4011
https://issues.jasig.org/browse/UP-4012

Adding respondr theme skin and gallery as hidden to the -lo.templates to allow the proper display in DLM fragment administration.  Adjusted the gallery code in xsl to only be present if the user is authenticated(otherwise the gallery isn't present).  In fragment administration there was a bug where $ was not mapped to up.jQuery causing the page to not work properly which has been adjusted.

This addresses the gallery not being present while administering a fragment as well(UP-4012)
