### PR TITLE
UP-4009: Adjusting the xsl to only display the gallery when portal view is not focused.

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
@@ -232,7 +232,7 @@
      | This template renders portlets in the top-left logo area.
     -->
     <xsl:template name="region.customize">
-        <xsl:if test="upAuth:hasPermission('UP_SYSTEM', 'CUSTOMIZE', 'ALL')">
+        <xsl:if test="upAuth:hasPermission('UP_SYSTEM', 'CUSTOMIZE', 'ALL') and $PORTAL_VIEW!='focused'">
             <xsl:if test="//region[@name='customize']/channel">
                 <div id="region-customize" class="container">
                     <div id="customizeOptionsWrapper">

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -517,6 +517,7 @@
                 }
             });
             </xsl:if>
+    <xsl:if test="$AUTHENTICATED='true' and $PORTAL_VIEW!='focused'">
             var layoutPreferences = up.LayoutPreferences("body", {
                 tabContext: '<xsl:value-of select="$TAB_CONTEXT"/>',
                 numberOfPortlets: '<xsl:value-of select="count(content/column/channel)"/>',
@@ -553,6 +554,7 @@
         if(layoutPreferences.components.gallery) {
             layoutPreferences.components.gallery.openGallery();
         }
+    </xsl:if>
     });
     </script>
 


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4009

Adjusting the xsl to only display the gallery when portal view is not focused.
