### PR TITLE
UP-3998 ignore JpaClusterLockDaoTest.testConcurrentCreateLocking().

### DIFF
--- a/uportal-war/src/test/java/org/jasig/portal/concurrency/locking/JpaClusterLockDaoTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/concurrency/locking/JpaClusterLockDaoTest.java
@@ -40,6 +40,7 @@ import org.jasig.portal.concurrency.CallableWithoutResult;
 import org.jasig.portal.test.BasePortalJpaDaoTest;
 import org.jasig.portal.test.ThreadGroupRunner;
 import org.jasig.portal.utils.threading.ThrowingRunnable;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
@@ -151,9 +152,14 @@ public class JpaClusterLockDaoTest extends BasePortalJpaDaoTest {
         mutex = clusterLockDao.getClusterMutex(mutexName);
         assertFalse(mutex.isLocked());
     }
-    
 
-    @Test
+
+    /**
+     * This test turns out to be nondeterministic under load and so can yield false-negatives
+     * (failures that don't seem to actually indicate a regression).
+     * @throws InterruptedException
+     */
+    @Ignore
     public void testConcurrentCreateLocking() throws InterruptedException  {
         reset(portalInfoProvider);
         when(portalInfoProvider.getUniqueServerName()).thenReturn("ServerA");


### PR DESCRIPTION
because it is non-deterministically false-failing.

See also:
- [UP-3998](https://issues.jasig.org/browse/UP-3998)
- [uportal-user@ discussion](http://thread.gmane.org/gmane.comp.java.jasig.uportal/16875)

This changeset chooses to go narrow, adding `@Ignore` of only the test method most recently falsely failing in UW-Madison's portal build process.  Arguably should take the opportunity to go wider and `@Ignore` more potentially false-failing test cases in `JpaClusterLockDaoTest` rather than waiting for them to be an annoyance.
