### PR TITLE
UP-4010 - Respondr View changes (mobile, emergency portlet, etc)

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
@@ -234,7 +234,7 @@
     <xsl:template name="region.customize">
         <xsl:if test="upAuth:hasPermission('UP_SYSTEM', 'CUSTOMIZE', 'ALL')">
             <xsl:if test="//region[@name='customize']/channel">
-                <div id="region-customize" class="container">
+                <div id="region-customize" class="container hidden-xs">
                     <div id="customizeOptionsWrapper">
                         <div id="customizeOptions" class="collapse">
                                 <xsl:for-each select="//region[@name='customize']/channel">

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/content.less
@@ -194,6 +194,22 @@
         }
     }
 
+    #portalTip,
+    #region-customize {
+        display: none;
+    }
+
+    section.emergency-alert {
+        background-color: @emergency-alert-background-color;
+        margin-bottom: 1em;
+        border-radius: 5px;
+
+        .view-alert {
+            padding-top: 15px !important;
+            padding-bottom: 30px !important;
+        }
+    }
+
 /* ==========================================================================
    Responsive Design
    ========================================================================== */
@@ -208,6 +224,10 @@
  */
 
 @media only screen and (min-width: 769px) {
+    #portalTip,
+    #region-customize {
+        display: block;
+    }
     .portal-content {
         padding: 0 0 0 20px;
     }

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/header.less
@@ -34,8 +34,10 @@
     right: 0;
 
     .logout-launcher {
+        margin-left: 10px;
+
         a.portal-logout {
-            // color: @user-portal-logout-btn-text-color;
+            color: @user-portal-logout-btn-text-color;
         }
     }
 }

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
@@ -19,9 +19,6 @@
 
 .portal-nav {
     background: @navbar-background-color;
-    border-top: @navbar-border-size solid @navbar-border-color;
-    border-bottom: @navbar-border-size solid @navbar-border-color;
-    font-weight: @navbar-item-font-weight;
 
     .menu-toggle {
         position: absolute;
@@ -168,6 +165,10 @@
  * Convert navigation from toggled block menu to inline tabs.
  */
     .portal-nav {
+        background: @navbar-background-color;
+        border-top: @navbar-border-size solid @navbar-border-color;
+        border-bottom: @navbar-border-size solid @navbar-border-color;
+        font-weight: @navbar-item-font-weight;
 
         .menu-toggle {
             display: none;

--- a/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/less/variables.less
@@ -131,6 +131,14 @@
  * Header
  */
 @notification-icon-color: #fff;
+
+@user-portal-logout-btn-text-color: #fff;
+
+/**
+ * Emergency Alert
+ */
+@emergency-alert-background-color: rgb(123, 0, 0);
+
 /**
  * Nav
  */


### PR DESCRIPTION
When in mobile view, some of the elements don't align up properly. Restructured some of the code to be "mobile first".

Added a background to the emergency alert notification portlet. This allows various skins to set it accordingly.

Hide the tips and customize draw button when viewing on a small device.

Added variable for setting the logout link color.
