### PR TITLE
Upgrade to  Resource Server 1.0.38 and Bootstrap 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <pluto.version>2.1.0-M3</pluto.version>
         <portlet-api.version>2.0</portlet-api.version>
         <quartz.version>1.8.4</quartz.version>
-        <resource-server.version>1.0.37</resource-server.version>
+        <resource-server.version>1.0.38</resource-server.version>
         <servlet-api.version>3.0.1</servlet-api.version>
         <slf4j.version>1.7.4</slf4j.version>
         <spring-framework.version>3.1.4.RELEASE</spring-framework.version>

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/common_skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/common_skin.xml
@@ -46,8 +46,8 @@
     <js included="aggregated" resource="true">/ResourceServingWebapp/rs/jqueryui/1.10.3/i18n/jquery-ui-i18n.min.js</js>
     -->
 
-    <js included="plain">/ResourceServingWebapp/rs/bootstrap/3.0.0/js/bootstrap-3.0.0.js</js>
-    <js included="aggregated">/ResourceServingWebapp/rs/bootstrap/3.0.0/js/bootstrap-3.0.0.min.js</js>
+    <js included="plain">/ResourceServingWebapp/rs/bootstrap/3.1.1/js/bootstrap.js</js>
+    <js included="aggregated">/ResourceServingWebapp/rs/bootstrap/3.1.1/js/bootstrap.min.js</js>
 
     <!-- Fluid must come after Bootstrap.  Issue found with Respondr.  When you click on the 'Manage Portlets' link,
      | fluid was calling that.container.tooltip("widget"); which should call jQueryUI's tooltip function, but

--- a/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin/skin.xml
@@ -32,9 +32,6 @@
   <css included="plain">/ResourceServingWebapp/rs/fontawesome/4.0.3/css/font-awesome.css</css>
   <css included="aggregated">/ResourceServingWebapp/rs/fontawesome/4.0.3/css/font-awesome.min.css</css>
   
-  <css included="plain">/ResourceServingWebapp/rs/bootstrap/3.0.0/css/bootstrap-3.0.0.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/bootstrap/3.0.0/css/bootstrap-3.0.0.min.css</css>
-
   <!-- Default jQuery UI theme.  Point this to a custom jQuery UI theme if desired. -->
   <css included="plain">/ResourceServingWebapp/rs/jqueryui/1.10.3/theme/smoothness/jquery-ui-1.10.3-smoothness.css</css>
   <css included="aggregated">/ResourceServingWebapp/rs/jqueryui/1.10.3/theme/smoothness/jquery-ui-1.10.3-smoothness.min.css</css>


### PR DESCRIPTION
- Upgraded resource server
- Removed redundant bootstrap css integration (since we pulled the less into the defaultSkin)
- Changed the bootstrap JS to 3.1.1
