### PR TITLE
UP-3742: Correct rendering of Audit DLM fragment in case of unknown portlets

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/dlm/remoting/FragmentListController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/dlm/remoting/FragmentListController.java
@@ -153,7 +153,10 @@ public class FragmentListController {
                 for (int i=0; i < channelFNames.getLength(); i++) {
                     String fname = channelFNames.item(i).getTextContent();
                     IPortletDefinition pDef = portletRegistry.getPortletDefinitionByFname(fname);
-                    portlets.add(pDef.getTitle());
+
+                    if (null != pDef) {
+                        portlets.add(pDef.getTitle());
+                    }
                 }
             }
             


### PR DESCRIPTION
Unknown portlets are now ignored when rendering Audit DLM fragment, rather than causing a NullPointerException.
