### PR TITLE
UP-4038 : fix http redirect for sonatype snapshot repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <repository>            
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <releases><enabled>false</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </repository>
@@ -69,7 +69,7 @@
         <pluginRepository>            
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <releases><enabled>false</enabled></releases>
             <snapshots><enabled>true</enabled></snapshots>
         </pluginRepository>


### PR DESCRIPTION
Issue : https://gist.github.com/timlevett/3e25082b1a7e923fc9fc

Solution suggested : https://answers.atlassian.com/questions/73845/suddenly-maven-does-not-compile-unable-to-get-dependency-information-related-to-velocity

> Changing your config to use https:// solves the problem.Still, this is bug in SDK as the URL used to generate the pom.xml file is now invalid.And also a bug in maven (for not properly detecting 301 redirects).
