### PR TITLE
UP-4153 Contain failure to activate a fragment.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/dlm/RDBMDistributedLayoutStore.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/dlm/RDBMDistributedLayoutStore.java
@@ -1327,11 +1327,19 @@ public class RDBMDistributedLayoutStore extends RDBMUserLayoutStore {
                 logger.debug("Checking applicability of the following fragment: {}", fragmentDefinition.getName());
 
                 if (fragmentDefinition.isApplicable(person)) {
-                    final UserView userView = activator.getUserView(fragmentDefinition, locale);
-                    if (userView != null) {
-                        applicables.add(userView.layout);
+                    try {
+                        final UserView userView = activator.getUserView(fragmentDefinition, locale);
+                        if (userView != null) {
+                            applicables.add(userView.layout);
+                        }
+                        fragmentNames.add(fragmentDefinition.getName());
+                    } catch (Exception e) {
+                        // Unable to activate a fragment?  Drop that one fragment from the layout, but
+                        // don't fail to render other potentially unbroken potentially useful fragments.
+                        logger.error("Error activating fragment {} for user {}.", fragmentDefinition, person, e);
+                        // TODO: surface a not-totally-disabling error experience to the user
+                        // because something is very wrong.
                     }
-                    fragmentNames.add(fragmentDefinition.getName());
                 }
             }
         }


### PR DESCRIPTION
Failing to activate a fragment should result in that fragment failing to activate, not the portal experience completely failing.

In response new adopter issue [reported on uportal-user@](https://lists.wisc.edu/read/messages?id=33030191#33030191) ; tracked in JIRA at [UP-4153](https://issues.jasig.org/browse/UP-4153).

I'll be the first to admit this fix may not be good enough and we really need to surface the error to the user because while this fix will allow them to have a degraded portal experience, it's a degraded experience missing some content they were intended to enjoy, and it's potentially a _very_ or _unusably_ degraded experience depending on what the missing fragments are (regions?).
