### PR TITLE
Change labels and URLs from Jasig to Apereo.

### DIFF
--- a/NOTICE.template
+++ b/NOTICE.template
@@ -1,6 +1,6 @@
-Copyright 2010, JA-SIG, Inc.
-This project includes software developed by Jasig.
-http://www.jasig.org/
+Copyright 2010-2014, Apereo Foundation
+This project includes software developed by the Apereo Foundation.
+http://www.apereo.org/
 
 Licensed under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 For more detailed help please refer to the [uPortal Manual](https://wiki.jasig.org/display/UPM40/Home)
 
-Additional information about uPortal is available on the [uPortal Home Page](http://www.jasig.org/uportal)
+Additional information about uPortal is available on the [uPortal Home Page](http://www.apereo.org/uportal)
 or in the [uPortal Wiki](https://wiki.jasig.org/display/UPC/Home)
 
 ## Travis-CI Continuous Integration

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/jasig-news.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/jasig-news.portlet-definition.xml
@@ -20,10 +20,11 @@
 
 -->
 <portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
-    <title>Jasig News</title>
-    <name>Jasig News</name>
+    <title>Apereo News</title>
+    <name>Apereo News</name>
+    <!-- retaining legacy fname so that this updated configuration updates old instances of this portlet. -->
     <fname>jasig-news</fname>
-    <desc>Jasig News channel</desc>
+    <desc>Apereo news feed.</desc>
     <type>RSS</type>
     <timeout>10000</timeout>
     <portlet-descriptor>
@@ -55,11 +56,13 @@
     <portlet-preference>
         <name>name</name>
         <readOnly>false</readOnly>
-        <value>Jasig News</value>
+        <value>Apereo News</value>
     </portlet-preference>
     <portlet-preference>
         <name>url</name>
         <readOnly>false</readOnly>
+        <!-- would be great to stop depending on jasig.org, but
+        do not see any RSS feed off of the new Apereo.org -->
         <value>http://jasig.org/jasig-news/feed</value>
     </portlet-preference>
     <portlet-preference>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/jasig-test-portlet.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/jasig-test-portlet.portlet-definition.xml
@@ -20,10 +20,11 @@
 
 -->
 <portlet-definition xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd">
-    <title>JASIG Test Portlet</title>
-    <name>JASIG Test Portlet</name>
+    <title>uPortal Test Portlet</title>
+    <name>uPortal Test Portlet</name>
+    <!-- This fname retains jasig in it so it continues to match upgrades of old deployments of this portlet -->
     <fname>jasig-test-portlet</fname>
-    <desc>Test Portlet from JASIG</desc>
+    <desc>Test Portlet from Apereo uPortal</desc>
     <type>Portlet</type>
     <timeout>60000</timeout>
     <portlet-descriptor>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/please-register.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/please-register.portlet-definition.xml
@@ -52,7 +52,7 @@
                 &lt;h2&gt;Please register&lt;/h2&gt;
                 
                 &lt;p&gt;
-                    Please &lt;a href=&quot;http://www.jasig.org/uportal/deployments&quot; 
+                    Please &lt;a href=&quot;http://www.apereo.org/uportal/deployments&quot;
                     target=&quot;_blank&quot;&gt;list your deployment of uPortal alongside 
                     the many others already registered&lt;/a&gt; so that the many 
                     people who have made uPortal possible can know that their 

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/tips.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/tips.portlet-definition.xml
@@ -78,7 +78,7 @@
     <portlet-preference>
         <name>tips</name>
         <readOnly>true</readOnly>
-        <value>The Service Desk can answer technical questions at (555) 555-5555 or servicedesk@jasig.org</value>
+        <value>The Service Desk can answer technical questions at (555) 555-5555 or servicedesk@apereo.org</value>
         <value>When using a public computer, don't forget to sign out, or close the browser, when you're done</value>
         <value>Quarters to semesters questions? Ask your advisor or visit the Student Help Center</value>
         <value>New portlets can be added to your layout by clicking on 'Customize'</value>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/uportal-home-page.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/uportal-home-page.portlet-definition.xml
@@ -52,6 +52,6 @@
     <portlet-preference>
         <name>url</name>
         <readOnly>false</readOnly>
-        <value>http://uportal.org/</value>
+        <value>http://www.apereo.org/uportal</value>
     </portlet-preference>
 </portlet-definition>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/uportal-links.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/uportal-links.portlet-definition.xml
@@ -51,17 +51,17 @@
             
                 &lt;h2&gt;uPortal Links&lt;/h2&gt;
                 &lt;ul&gt;
-                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.jasig.org/uportal&quot;&gt;uPortal Home&lt;/a&gt;&lt;/li&gt;
+                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.apereo.org/uportal&quot;&gt;uPortal Home&lt;/a&gt;&lt;/li&gt;
                     &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://wiki.jasig.org/display/UPM40/Home&quot;&gt;uPortal 4 Manual&lt;/a&gt;&lt;/li&gt;
-                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.jasig.org/uportal/download/all&quot;&gt;Download uPortal&lt;/a&gt;&lt;/li&gt;
+                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.apereo.org/uportal/download&quot;&gt;Download uPortal&lt;/a&gt;&lt;/li&gt;
                     &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://wiki.jasig.org/display/UPC/Home&quot;&gt;uPortal Wiki&lt;/a&gt;&lt;/li&gt;
-                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.jasig.org/uportal/mailing-lists&quot;&gt;Join mailing lists&lt;/a&gt;&lt;/li&gt;
-                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.jasig.org/jasig-membership&quot;&gt;Become a Jasig member&lt;/a&gt;&lt;/li&gt;
-                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.jasig.org/jasig-support/solutions-providers&quot;&gt;uPortal commercial services and support&lt;/a&gt;&lt;/li&gt;
-                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://wiki.jasig.org/display/JSG/Newsletter&quot;&gt;Jasig newsletter&lt;/a&gt;&lt;/li&gt;
-                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.jasig.org/uportal/deployments&quot;&gt;uPortal-driven sites&lt;/a&gt;&lt;/li&gt;
-                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://issues.jasig.org/browse/UP&quot;&gt;uPortal Bug Tracker&lt;/a&gt;&lt;/li&gt;
-                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;https://wiki.jasig.org/display/PLT/Home&quot;&gt;Get additional portlets&lt;/a&gt;&lt;/li&gt;
+                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.apereo.org/uportal/mailing-lists&quot;&gt;Join mailing lists&lt;/a&gt;&lt;/li&gt;
+                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.apereo.org/content/member-organizations&quot;&gt;Become an Apereo Foundation member&lt;/a&gt;&lt;/li&gt;
+                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.apereo.org/uportal/support/solutions-providers&quot;&gt;uPortal commercial services and support&lt;/a&gt;&lt;/li&gt;
+                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.apereo.org/content/apereo-newsletters&quot;&gt;Apereo newsletter&lt;/a&gt;&lt;/li&gt;
+                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://www.apereo.org/uportal/deployments&quot;&gt;uPortal-driven sites&lt;/a&gt;&lt;/li&gt;
+                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;http://issues.jasig.org/browse/UP&quot;&gt;uPortal Issue Tracker&lt;/a&gt;&lt;/li&gt;
+                    &lt;li&gt;&lt;a target=&quot;_blank&quot; href=&quot;https://wiki.jasig.org/display/PLT/Home&quot;&gt;Browse additional portlets&lt;/a&gt;&lt;/li&gt;
                 &lt;/ul&gt;
             
         </value>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/uportal-news.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/uportal-news.portlet-definition.xml
@@ -60,7 +60,7 @@
     <portlet-preference>
         <name>url</name>
         <readOnly>false</readOnly>
-        <value>http://jasig.org/uportal-news/feed</value>
+        <value>http://www.apereo.org/uportal-news/feed</value>
     </portlet-preference>
     <portlet-preference>
         <name>summaryView</name>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/what-is-uportal.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/what-is-uportal.portlet-definition.xml
@@ -52,16 +52,16 @@
                 &lt;h2&gt;What is uPortal?&lt;/h2&gt;
                 
                 &lt;p&gt;
-                    &lt;a href=&quot;http://www.uportal.org&quot; target=&quot;_blank&quot;&gt;uPortal&lt;/a&gt; 
+                    &lt;a href=&quot;http://www.apereo.org/uportal&quot; target=&quot;_blank&quot;&gt;uPortal&lt;/a&gt;
                     is a free and open source Java-implemented web portal 
                     platform developed and maintained by participants drawn 
                     from across higher education under the coordination of 
-                    &lt;a href=&quot;http://www.ja-sig.org&quot; target=&quot;_blank&quot;&gt;Jasig&lt;/a&gt;. 
+                    &lt;a href=&quot;http://www.apereo.org/&quot; target=&quot;_blank&quot;&gt;Apereo&lt;/a&gt;.
                     uPortal can aggregate content, present self-service 
                     applications, personalize presentation and content on the 
-                    basis of groups and user attributes, and allow advanced 
+                    basis of groups and user attributes, drive mobile device applications, and allow advanced
                     end-user-participatory customization of the portal experience. 
-                    uPortal supports the JSR-168 Java portlet specification for 
+                    uPortal supports the JSR-286 and JSR-168 Java portlet specification for
                     including your custom applications within the portal.
                 &lt;/p&gt;
                 


### PR DESCRIPTION
Jasig is now (with Sakai and others) Apereo.  Adjust `NOTICE` template, hyperlinks, labels, and RSS feeds where feasible to reflect.

Also includes trivial edits to the about uPortal text to allude to uMobile and explicitly claim JSR-286 support.

Re-labels the Jasig News RSS feed reader to Apereo News, but does not change the URL away from `jasig.org` because equivalent `apereo.org` URL apparently not yet available.
