### PR TITLE
Ignore `JpaClusterLockDaoTest`s that involve sleeping.

### DIFF
--- a/uportal-war/src/test/java/org/jasig/portal/concurrency/locking/JpaClusterLockDaoTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/concurrency/locking/JpaClusterLockDaoTest.java
@@ -208,8 +208,12 @@ public class JpaClusterLockDaoTest extends BasePortalJpaDaoTest {
         mutex = clusterLockDao.getClusterMutex(mutexName);
         assertFalse(mutex.isLocked());
     }
-    
-    @Test
+
+    /**
+     * Ignoring this test because it is nondeterministic.
+     * @throws Exception
+     */
+    @Ignore
     public void testNotAbandoned() throws Exception  {
         //Used to make a 'mutable string'
         final AtomicReference<String> currentServer = new AtomicReference<String>("ServerA");
@@ -276,8 +280,12 @@ public class JpaClusterLockDaoTest extends BasePortalJpaDaoTest {
         mutex = clusterLockDao.getClusterMutex(mutexName);
         assertFalse(mutex.isLocked());
     }
-    
-    @Test
+
+    /**
+     * Ignoring this test because it is nondeterministic.
+     * @throws Exception
+     */
+    @Ignore
     public void testAbandoned() throws Exception  {
         //Used to make a 'mutable string'
         final AtomicReference<String> currentServer = new AtomicReference<String>("ServerA");


### PR DESCRIPTION
Sleeping is always non-deterministic.  Ignore the remaining `JpaClusterLockDaoTest`s that involve sleeping.
