### PR TITLE
UP-4069 : fixed issue with medium sized screen not resizing correctly

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/regions.xsl
@@ -176,7 +176,7 @@
     -->
     <xsl:template name="region.sidebar-left">
         <xsl:if test="//region[@name='sidebar-left']/channel">
-            <div id="region-sidebar-left" class="col-sm-2">
+            <div id="region-sidebar-left" class="col-md-2">
                 <xsl:for-each select="//region[@name='sidebar-left']/channel">
                     <xsl:call-template name="regions.portlet.decorator" />
                 </xsl:for-each>
@@ -192,7 +192,7 @@
     <xsl:template name="region.pre-content">
         <xsl:if test="//region[@name='pre-content']/channel">
             <div id="region-pre-content" class="row-fluid">
-                <div class="col-sm-12">
+                <div class="col-md-12">
                     <xsl:for-each select="//region[@name='pre-content']/channel">
                         <xsl:call-template name="regions.portlet.decorator" />
                     </xsl:for-each>
@@ -208,7 +208,7 @@
     -->
     <xsl:template name="region.sidebar-right">
         <xsl:if test="//region[@name='sidebar-right']/channel">
-            <div id="region-sidebar-right" class="col-sm-2">
+            <div id="region-sidebar-right" class="col-md-2">
                 <xsl:for-each select="//region[@name='sidebar-right']/channel">
                     <xsl:call-template name="regions.portlet.decorator" />
                 </xsl:for-each>


### PR DESCRIPTION
In respondr.xsl we are using col-md for the middle column, so this changes the side columns to use these as well.  Also does this for precontent region.
## Before:

![image](https://cloud.githubusercontent.com/assets/3534544/2769261/f92b2792-ca4e-11e3-9ad0-232267c11485.png)
## After

![image](https://cloud.githubusercontent.com/assets/3534544/2769257/f098182e-ca4e-11e3-8ced-b7a42e12c119.png)
