### PR TITLE
Adds meaning to a featured category

### DIFF
--- a/uportal-war/src/main/data/default_entities/group_membership/All_categories.group-membership.xml
+++ b/uportal-war/src/main/data/default_entities/group_membership/All_categories.group-membership.xml
@@ -27,6 +27,7 @@
   <children>
     <group>Administration</group>
     <group>Development</group>
+    <group>Featured</group>
     <group>Information</group>
     <group>uPortal</group>
   </children>

--- a/uportal-war/src/main/data/default_entities/group_membership/Featured.group-membership.xml
+++ b/uportal-war/src/main/data/default_entities/group_membership/Featured.group-membership.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<group script="classpath://org/jasig/portal/io/import-group_membership_v3-2.crn">
+  <name>Featured</name>
+  <entity-type>org.jasig.portal.portlet.om.IPortletDefinition</entity-type>
+  <creator>system</creator>
+  <description>Featured Portlets</description>
+  <children/>
+</group>

--- a/uportal-war/src/main/data/default_entities/portlet-definition/portletmarketplace.portlet-definition.xml
+++ b/uportal-war/src/main/data/default_entities/portlet-definition/portletmarketplace.portlet-definition.xml
@@ -31,6 +31,7 @@
         <ns2:portletName>PortletMarketplace</ns2:portletName>
     </portlet-descriptor>
     <category>uPortal</category>
+    <category>Featured</category>
     <group>Everyone</group>
     <parameter>
         <name>iconUrl</name>

--- a/uportal-war/src/main/java/org/jasig/portal/portlets/marketplace/PortletMarketplaceController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/marketplace/PortletMarketplaceController.java
@@ -19,6 +19,7 @@
 
 package org.jasig.portal.portlets.marketplace;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -69,7 +70,7 @@ public class PortletMarketplaceController {
     private static String SHOW_ROOT_CATEGORY_PREFERENCE_NAME="showRootCategory";
 
     private IMarketplaceService marketplaceService;
-
+    private static String FEATURED_CATEGORY_NAME="Featured";
 	
 	private IPortalRequestUtils portalRequestUtils;
 	private IPortletDefinitionRegistry portletDefinitionRegistry;
@@ -227,6 +228,10 @@ public class PortletMarketplaceController {
         @SuppressWarnings("unchecked")
         Set<PortletCategory> categoryList = (Set<PortletCategory>) registry.get("categories");
 
+        @SuppressWarnings("unchecked")
+        Set<MarketplacePortletDefinition> featuredPortlets = (Set<MarketplacePortletDefinition>) registry.get("featured");
+        model.addAttribute("featuredList", featuredPortlets);
+        
         //Determine if the marketplace is going to show the root category
         String showRootCategoryPreferenceValue = preferences.getValue(SHOW_ROOT_CATEGORY_PREFERENCE_NAME, "false");
         boolean showRootCategory = Boolean.parseBoolean(showRootCategoryPreferenceValue);
@@ -260,12 +265,22 @@ public class PortletMarketplaceController {
 
         final Set<MarketplacePortletDefinition> visiblePortlets =
                 this.marketplaceService.browseableMarketplaceEntriesFor(user);
-
+        
+        @SuppressWarnings("unchecked")
         final Set<PortletCategory> visibleCategories =
                 this.marketplaceService.browseableNonEmptyPortletCategoriesFor(user);
 
+        Set<MarketplacePortletDefinition> featuredPortlets = new HashSet<MarketplacePortletDefinition>();
+        for (MarketplacePortletDefinition currentPortlet : visiblePortlets) {
+            for(PortletCategory category: currentPortlet.getParentCategories()){
+                if(FEATURED_CATEGORY_NAME.equalsIgnoreCase(category.getName())){
+                    featuredPortlets.add(currentPortlet);
+                }
+            }
+        }
         registry.put("portlets", visiblePortlets);
         registry.put("categories", visibleCategories);
+        registry.put("featured", featuredPortlets);
         return registry;
     }
 }

--- a/uportal-war/src/main/resources/properties/i18n/Messages.properties
+++ b/uportal-war/src/main/resources/properties/i18n/Messages.properties
@@ -246,6 +246,7 @@ favorites.stop.editing=Stop editing favorites
 favorites.unfavorite.fail.parameterized=The portal failed to unfavorite {0}.  Try again later.  Please contact support if this issue persists.
 favorites.unfavorite.fail.lack.permission.parameterized=You lack permission to unfavorite {0}.
 favorites.unfavorite.success.parameterized=You have unfavorited {0}.
+featured=Featured
 feed.name=Feed Name
 file.name=File Name
 file.upload.queue=File Upload Queue

--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/view.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/view.jsp
@@ -227,11 +227,57 @@
     padding-top: 1em;
 }
 
+#${n}marketplace .marketplaceSection{
+    border-bottom-style:dotted;
+    border-width:thin;
+}
 
 </style>
 
 
 <div id="${n}marketplace">
+
+<c:if test="${fn:length(featuredList) > 0}">
+    <div id="${n}featured" class="marketplaceSection">
+        <div>
+            <span><strong><spring:message code="featured" text="Featured" /></strong></span><br>
+        </div>
+        <c:set var="endRowPortletCounter" value="0"/>
+        <div class="row">
+            <c:if test="${fn:length(featuredList)mod 2!=0 }">
+                <div class="col-xs-3">
+                <c:set var="endRowPortletCounter" value="1" />
+                </div>
+            </c:if>
+            <c:forEach var="featuredPortlet" items="${featuredList}" varStatus="status">
+                <portlet:renderURL var="entryURL" windowState="MAXIMIZED" >
+                    <portlet:param name="action" value="view"/>
+                    <portlet:param name="fName" value="${featuredPortlet.FName}"/>
+                </portlet:renderURL>
+                <div class="col-xs-6 col-sm-6 text-center">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                        <a href="${entryURL}">
+                            <div>
+                                <c:out value="${featuredPortlet.title}"/>
+                            </div>
+                        </a>
+                        </div>
+                        <div class="panel-body">
+                            <div>
+                                <c:out value="${featuredPortlet.description}"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <c:if test="${(endRowPortletCounter + status.count) mod 2 ==0}">
+                    <div class="clearfix"></div>
+                </c:if>
+            </c:forEach>
+        </div>
+    </div>
+</c:if>
+
 
 <div id="${n}categoryListContainer" class="marketplace_center_text panel panel-default" style="display:none">
     <div class="panel-body">
@@ -359,8 +405,9 @@
                 "<button type=\"button\" id=\"${n}category-sort-button\" class=\"btn btn-default category-sort-button\">${categoryLabel}</button>"+
                 "</div><br><br></div>");
             $("#${n}categoryListContainer").insertAfter($(".${n}sort_buttons"));
+            $("#${n}featured").insertAfter($("#${n}marketplace .top"));
             $("#${n}marketplace div.sort_info").html("<div><BR><BR><span><strong>${browseBy}</strong><br><br></div>");
-            $("#${n}marketplace div.dataTables_filter").append("<form action='${entryURL}'><button>${labelSearch}</button></form>");
+            $("#${n}marketplace div.dataTables_filter").append("<form action='${entryURL}'><button>${labelSearch}</button></form><br>");
 
             var setFilter = function(text){
                 myDataTable.fnFilter(text);
@@ -369,6 +416,8 @@
             var sortColumns = function(column){
                 myDataTable.fnSort([[column, 'asc']]);
             }
+            
+            $("#${n}marketplace .dataTables_filter").addClass("marketplaceSection");
 
             $(".${n}marketplace_category_link").click(function(){
                 setFilter(this.textContent);


### PR DESCRIPTION
The marketplace controller will send to the view a list of portlets considered "featured".  Featured portlets are portlets that are in the category of "Featured".  Here is the controller static variable:
![image](https://cloud.githubusercontent.com/assets/5521429/2769704/07423e50-ca55-11e3-9be6-ca54ef0fce83.png)
(show root category preference name snuck in the screen shot).

Anything in this category will appear in the featured section in the marketplace list page.  1 featured portlet will be centered.  2 will appear side by side. 3 will appear as 1 in the middle, 2 side by side, etc.  0 featured portlets will result in this entire section not appearing.  A set is returned to the view, so the ordering does switch.

![image](https://cloud.githubusercontent.com/assets/5521429/2769690/c1d1cd36-ca54-11e3-9e85-7f7f0b439609.png)

![image](https://cloud.githubusercontent.com/assets/5521429/2769762/98c5bd66-ca55-11e3-9928-d3b532aaee56.png)

![image](https://cloud.githubusercontent.com/assets/5521429/2769777/b99af218-ca55-11e3-971e-71b04099ae37.png)

![image](https://cloud.githubusercontent.com/assets/5521429/2769786/d0b70630-ca55-11e3-81f3-693a33e347e3.png)

![image](https://cloud.githubusercontent.com/assets/5521429/2769821/42b687b0-ca56-11e3-97ac-251cd7875636.png)

I admit the whole display isn't particularly appealing.  This is a starting point.

**NOTE** the screenshots are from UW Madison's portal.  A few things not affected by this pull request look different.

**2nd NOTE** There was a discussion if constructing a featured portlet list should be part of the controller or should be in the service layer.  Presented as being in the controller.  Thoughts welcome.
