### PR TITLE
Remove unused getters in Marketplace Service and Portlet

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/MarketplaceService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/MarketplaceService.java
@@ -145,20 +145,13 @@ public class MarketplaceService implements IMarketplaceService {
 
     }
 
-    // Getters and setters below here.
-
-    public IPortletDefinitionRegistry getPortletDefinitionRegistry() {
-        return portletDefinitionRegistry;
-    }
+    // JavaBean property setters below here.
+    // getters omitted because no use cases for reading the properties
 
     @Autowired
     public void setPortletDefinitionRegistry(final IPortletDefinitionRegistry portletDefinitionRegistry) {
         Validate.notNull(portletDefinitionRegistry, "Portlet definition registry must not be null.");
         this.portletDefinitionRegistry = portletDefinitionRegistry;
-    }
-
-    public IPortletCategoryRegistry getPortletCategoryRegistry() {
-        return portletCategoryRegistry;
     }
 
     @Autowired

--- a/uportal-war/src/main/java/org/jasig/portal/portlets/marketplace/PortletMarketplaceController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/marketplace/PortletMarketplaceController.java
@@ -82,9 +82,6 @@ public class PortletMarketplaceController {
 	private IPortletDefinitionDao portletDefinitionDao;
 	private IMarketplaceRatingDao marketplaceRatingDAO;
 
-    public IMarketplaceService getMarketplaceService() {
-        return marketplaceService;
-    }
 
     @Autowired
     public void setMarketplaceService(IMarketplaceService marketplaceService) {


### PR DESCRIPTION
Remove unused getters for `portletDefinitionRegistry` and `portletCategoryRegistry` JavaBean properties in `MarketplaceService` and for `marketplaceService` in `PortletMarketplaceController`.

Follows up on feedback at https://github.com/Jasig/uPortal/pull/312#discussion_r12190297 to apply the remove as it applies to classes already in `master`.
