### PR TITLE
Removed unique constraint from up_aggr_portlet_mapping.portlet_name

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/portlets/AggregatedPortletMappingImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/portlets/AggregatedPortletMappingImpl.java
@@ -62,7 +62,7 @@ public final class AggregatedPortletMappingImpl implements AggregatedPortletMapp
     @Column(name="ID")
     private final long id;
     
-    @Column(name = "PORTLET_NAME", length = 128, nullable = false, unique = true)
+    @Column(name = "PORTLET_NAME", length = 128, nullable = false)
     private final String name;
 
     @NaturalId


### PR DESCRIPTION
We had an issue with aggregation where we had a portlet with fname = "hrs-help" and name = "hrs help".  We then introduced a second portlet with a different fname but the same name.  We then realized the name must be unique so we changed the original name to "UW HRS Help" and named the new portlet "hrs help".  When the aggregator tried to insert a row into this aggregation portlet mapping it erred out which halted aggregation. 

The work-around was to clean up the data manually, but added in an item to remove this constraint as it is not necessary since there is already a constraint on fname.
