### PR TITLE
Trivial: fix null arg validation message.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/security/AuthorizationPrincipalHelper.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/AuthorizationPrincipalHelper.java
@@ -41,7 +41,7 @@ public final class AuthorizationPrincipalHelper {
      */
     public static IAuthorizationPrincipal principalFromUser(final IPerson user) {
 
-        Validate.notNull(user, "Cannot determine marketplace entries for null user.");
+        Validate.notNull(user, "Cannot determine an authorization principal for null user.");
 
         final EntityIdentifier userEntityIdentifier = user.getEntityIdentifier();
         Validate.notNull(user, "The user object is defective: lacks entity identifier.");


### PR DESCRIPTION
Make `principalFromUser` `null` validation failure not-Marketplace-specific.

Credit to @drewwills for catching this in https://github.com/Jasig/uPortal/commit/e974b1ea294653ca7b67aa9b39a021e1e3ab5fb1#commitcomment-6295316 .
