### PR TITLE
Add dependency on commons-lang3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
         <commons-httpcomponents.version>4.3.2</commons-httpcomponents.version>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
+        <commons-lang3.version>3.3.2</commons-lang3.version>
         <commons-pool.version>1.6</commons-pool.version>
         <commons-math3.version>3.2</commons-math3.version>
         <dom4j.version>1.6.1</dom4j.version>
@@ -396,6 +397,11 @@
                 <groupId>commons-pool</groupId>
                 <artifactId>commons-pool</artifactId>
                 <version>${commons-pool.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -123,6 +123,11 @@
             <groupId>commons-pool</groupId>
             <artifactId>commons-pool</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
         
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Adds Maven dependency on `commons-lang3`.

Apparently this dependency was available through a transitive dependency, and some Marketplace-and-related code is already trying to use Commons Lang 3, but it wasn't actually a dependency in uPortal.  This change makes it one.
## Does not disrupt commons-lang 2

`commons-lang3` uses a different package than does old `commons-lang` (2), such that adding lang3 doesn't disrupt dependency on and usage of lang2.  Isn't that nice? :)
## Deferred work: 
- upgrade existing Commons Lang (2) usages to Commons Lang 3 so we can drop dependency on Commons Lang 2.
