### PR TITLE
Uses the next version of Bookmarks Portlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <!-- WAR Dependency Version Properties -->
         <AnnouncementsPortlet.version>2.0.0</AnnouncementsPortlet.version>
         <basiclti-portlet.version>1.4.2</basiclti-portlet.version>
-        <BookmarksPortlet.version>1.0.11</BookmarksPortlet.version>
+        <BookmarksPortlet.version>1.0.14</BookmarksPortlet.version>
         <CalendarPortlet.version>2.1.3-M4</CalendarPortlet.version>
         <cas-server.version>3.5.2.1</cas-server.version>
         <cas-proxy-test-portlet.version>1.0.0-RC3</cas-proxy-test-portlet.version>

--- a/uportal-portlets-overlay/BookmarksPortlet/src/main/webapp/WEB-INF/web.xml
+++ b/uportal-portlets-overlay/BookmarksPortlet/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<web-app version="2.4" 
+    xmlns="http://java.sun.com/xml/ns/j2ee" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+	
+    <display-name>Bookmarks Portlet</display-name>
+    
+    <!--
+     | Key of the system property that should specify the root directory of this
+     | web app. Applied by WebAppRootListener or Log4jConfigListener.
+     +-->
+    <context-param>
+        <param-name>webAppRootKey</param-name>
+        <param-value>bookmarks.root</param-value>
+    </context-param>
+    
+    <context-param>
+        <param-name>log4jConfigLocation</param-name>
+        <param-value>/WEB-INF/log4j.properties</param-value>
+    </context-param>
+
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>/WEB-INF/context/applicationContext.xml</param-value>
+    </context-param>
+
+    <!--
+     | The order of these listeners is important and should not be changed
+     +-->
+    <listener>
+        <listener-class>org.springframework.web.util.WebAppRootListener</listener-class>
+    </listener>
+    
+    <listener>
+        <listener-class>org.springframework.web.util.Log4jConfigListener</listener-class>
+    </listener>
+    
+    <listener>
+        <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+    </listener>
+    
+    <filter>
+        <filter-name>GzipFilter</filter-name>
+        <filter-class>net.sf.ehcache.constructs.web.filter.GzipFilter</filter-class>
+    </filter>
+    
+    <filter-mapping>
+        <filter-name>GzipFilter</filter-name>
+        <url-pattern>*.js</url-pattern>
+    </filter-mapping>
+    
+    <filter-mapping>
+        <filter-name>GzipFilter</filter-name>
+        <url-pattern>*.css</url-pattern>
+    </filter-mapping>
+    
+    <!-- 
+     | This servlet is needed by the spring DispatcherPortlet for rendering.
+     +-->
+    <servlet>
+        <servlet-name>ViewRendererServlet</servlet-name>
+        <servlet-class>org.springframework.web.servlet.ViewRendererServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    
+    
+    <!-- [INSERT JSPC FRAGMENT HERE] -->
+
+    <servlet-mapping>
+        <servlet-name>ViewRendererServlet</servlet-name>
+        <url-pattern>/WEB-INF/servlet/view</url-pattern>
+    </servlet-mapping>
+</web-app>

--- a/uportal-war/src/main/data/quickstart_entities/portlet-definition/pbookmarks.portlet-definition.xml
+++ b/uportal-war/src/main/data/quickstart_entities/portlet-definition/pbookmarks.portlet-definition.xml
@@ -37,6 +37,10 @@
         <value>1</value>
     </parameter>
     <parameter>
+        <name>editable</name>
+        <value>true</value>
+    </parameter>
+    <parameter>
         <name>iconUrl</name>
         <value>/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/x-office-address-book.png</value>
     </parameter>


### PR DESCRIPTION
This pull request is to update to the latest version of the bookmarks portlet.  This shouldn't be merged until bookmarks portlet version 1.0.14 (or another) is released.  Depends on pull request: https://github.com/Jasig/BookmarksPortlet/pull/4.

Since this bookmarks portlet updates adds an edit mode, I didn't want to lose the needed changes.

Note, travisci will not approve this since version 1.0.14 of the bookmarks portlet does not exist.
