### PR TITLE
UP-4108 Changes to support CAS ClearPass in clustered uPortal environment

### DIFF
--- a/filters/data-test.properties
+++ b/filters/data-test.properties
@@ -64,6 +64,16 @@ environment.build.cas.context=/cas
 # in WEB-INF or resources directory for each portlet. This provides a
 # single point of control for most logging.
 
+# Clustered uPortal CAS Clearpass RMI URI list.
+# Needed if using CAS Clearpass and a clustered uPortal environment.  See https://issues.jasig.org/browse/UP-4108.
+# Replaces values in ehcache.xml.  Format is a pipe-separated list of uPortal machine IPs in the cluster (not including
+# this machine) and the cache name.  See http://ehcache.org/documentation/replication/rmi-replicated-caching for
+# more information.  The Manual RMI Peer Discovery must be uncommented in ehcache.xml.
+environment.build.cas.clearpass.cache.rmi.urls=//192.168.0.16:41001/org.jasig.cas.client.proxy.EhcacheBackedProxyGrantingTicketStorageImpl.cache|//192.168.0.17:41001/org.jasig.cas.client.proxy.EhcacheBackedProxyGrantingTicketStorageImpl.cache
+# Clustered uPortal CAS Clearpass RMI Listener port.  If using manual peering, this port should match the port
+# specified in the RMI URLs.  Range 1025 - 65536. Also used with automatic peer discovery.
+environment.build.cas.clearpass.cache.rmi.listenerPort=41001
+
 environment.build.log.rootLevel=INFO
 # Directory to place portal and portlet log files into.
 environment.build.log.logfileDirectory=${catalina.base}/logs

--- a/filters/live-nightly.properties
+++ b/filters/live-nightly.properties
@@ -60,6 +60,16 @@ environment.build.cas.server=up41-nightly.jasig.org
 environment.build.cas.protocol=https
 environment.build.cas.context=/cas
 
+# Clustered uPortal CAS Clearpass RMI URI list.
+# Needed if using CAS Clearpass and a clustered uPortal environment.  See https://issues.jasig.org/browse/UP-4108.
+# Replaces values in ehcache.xml.  Format is a pipe-separated list of uPortal machine IPs in the cluster (not including
+# this machine) and the cache name.  See http://ehcache.org/documentation/replication/rmi-replicated-caching for
+# more information.  The Manual RMI Peer Discovery must be uncommented in ehcache.xml.
+environment.build.cas.clearpass.cache.rmi.urls=//192.168.0.16:41001/org.jasig.cas.client.proxy.EhcacheBackedProxyGrantingTicketStorageImpl.cache|//192.168.0.17:41001/org.jasig.cas.client.proxy.EhcacheBackedProxyGrantingTicketStorageImpl.cache
+# Clustered uPortal CAS Clearpass RMI Listener port.  If using manual peering, this port should match the port
+# specified in the RMI URLs.  Range 1025 - 65536. Also used with automatic peer discovery.
+environment.build.cas.clearpass.cache.rmi.listenerPort=41001
+
 # Log4J values applied to portlets and portals.  See log4j.properties file
 # in WEB-INF or resources directory for each portlet. This provides a
 # single point of control for most logging.

--- a/filters/local.properties
+++ b/filters/local.properties
@@ -59,6 +59,16 @@ environment.build.cas.server=localhost:8080
 environment.build.cas.protocol=http
 environment.build.cas.context=/cas
 
+# Clustered uPortal CAS Clearpass RMI URI list.
+# Needed if using CAS Clearpass and a clustered uPortal environment.  See https://issues.jasig.org/browse/UP-4108.
+# Replaces values in ehcache.xml.  Format is a pipe-separated list of uPortal machine IPs in the cluster (not including
+# this machine) and the cache name.  See http://ehcache.org/documentation/replication/rmi-replicated-caching for
+# more information.  The Manual RMI Peer Discovery must be uncommented in ehcache.xml.
+environment.build.cas.clearpass.cache.rmi.urls=//192.168.0.16:41001/org.jasig.cas.client.proxy.EhcacheBackedProxyGrantingTicketStorageImpl.cache|//192.168.0.17:41001/org.jasig.cas.client.proxy.EhcacheBackedProxyGrantingTicketStorageImpl.cache
+# Clustered uPortal CAS Clearpass RMI Listener port.  If using manual peering, this port should match the port
+# specified in the RMI URLs.  Range 1025 - 65536. Also used with automatic peer discovery.
+environment.build.cas.clearpass.cache.rmi.listenerPort=41001
+
 # Log4J values applied to portlets and portals.  See log4j.properties file
 # in WEB-INF or resources directory for each portlet. This provides a
 # single point of control for most logging.

--- a/filters/prod.properties
+++ b/filters/prod.properties
@@ -63,6 +63,16 @@ environment.build.cas.context=/cas
 # in WEB-INF or resources directory for each portlet. This provides a
 # single point of control for most logging.
 
+# Clustered uPortal CAS Clearpass RMI URI list.
+# Needed if using CAS Clearpass and a clustered uPortal environment.  See https://issues.jasig.org/browse/UP-4108.
+# Replaces values in ehcache.xml.  Format is a pipe-separated list of uPortal machine IPs in the cluster (not including
+# this machine) and the cache name.  See http://ehcache.org/documentation/replication/rmi-replicated-caching for
+# more information.  The Manual RMI Peer Discovery must be uncommented in ehcache.xml.
+environment.build.cas.clearpass.cache.rmi.urls=//192.168.0.16:41001/org.jasig.cas.client.proxy.EhcacheBackedProxyGrantingTicketStorageImpl.cache|//192.168.0.17:41001/org.jasig.cas.client.proxy.EhcacheBackedProxyGrantingTicketStorageImpl.cache
+# Clustered uPortal CAS Clearpass RMI Listener port.  If using manual peering, this port should match the port
+# specified in the RMI URLs.  Range 1025 - 65536. Also used with automatic peer discovery.
+environment.build.cas.clearpass.cache.rmi.listenerPort=41001
+
 environment.build.log.rootLevel=WARN
 # Directory to place portal and portlet log files into.
 environment.build.log.logfileDirectory=${catalina.base}/logs

--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -674,6 +674,7 @@
                  +-->
                 <includes>
                     <include>org/apache/pluto/driver/container/pluto-configuration.properties</include>
+                    <include>properties/ehcache.xml</include>
                     <include>properties/portal.properties</include>
                     <include>properties/rdbm.properties</include>
                     <include>properties/security.properties</include>
@@ -691,6 +692,7 @@
                 <filtering>false</filtering>
                 <excludes>
                     <exclude>org/apache/pluto/driver/container/pluto-configuration.properties</exclude>
+                    <exclude>properties/ehcache.xml</exclude>
                     <exclude>properties/portal.properties</exclude>
                     <exclude>properties/rdbm.properties</exclude>
                     <exclude>properties/security.properties</exclude>

--- a/uportal-war/src/main/java/org/jasig/portal/concurrency/locking/ClusterMutex.java
+++ b/uportal-war/src/main/java/org/jasig/portal/concurrency/locking/ClusterMutex.java
@@ -56,7 +56,7 @@ import org.springframework.util.Assert;
         allocationSize=1
     )
 //THIS CLASS CANNOT BE CACHED
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.concurrency.locking.ClusterMutex-NaturalId")
 public class ClusterMutex implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/action/SearchRequestAggregationImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/action/SearchRequestAggregationImpl.java
@@ -18,17 +18,7 @@
  */
 package org.jasig.portal.events.aggr.action;
 
-import org.apache.commons.lang.Validate;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.NaturalIdCache;
-import org.jasig.portal.events.aggr.AggregationInterval;
-import org.jasig.portal.events.aggr.BaseAggregationImpl;
-import org.jasig.portal.events.aggr.DateDimension;
-import org.jasig.portal.events.aggr.TimeDimension;
-import org.jasig.portal.events.aggr.groups.AggregatedGroupMapping;
+import java.io.Serializable;
 
 import javax.persistence.Cacheable;
 import javax.persistence.Column;
@@ -41,7 +31,18 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 import javax.persistence.Transient;
-import java.io.Serializable;
+
+import org.apache.commons.lang.Validate;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+import org.jasig.portal.events.aggr.AggregationInterval;
+import org.jasig.portal.events.aggr.BaseAggregationImpl;
+import org.jasig.portal.events.aggr.DateDimension;
+import org.jasig.portal.events.aggr.TimeDimension;
+import org.jasig.portal.events.aggr.groups.AggregatedGroupMapping;
 
 /**
  * @author Chris Waymire (chris@waymire.net)
@@ -67,7 +68,7 @@ import java.io.Serializable;
                 @Index(name = "IDX_UP_SEARCH_REQ_GRP", columnNames = { "AGGR_GROUP_ID" }),
                 @Index(name = "IDX_UP_SEARCH_REQ_TRM", columnNames = { "SEARCH_TERM" })
         })
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.action.SearchRequestAggregationImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class SearchRequestAggregationImpl

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/concuser/ConcurrentUserAggregationImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/concuser/ConcurrentUserAggregationImpl.java
@@ -44,13 +44,10 @@ import org.hibernate.annotations.Index;
 import org.hibernate.annotations.NaturalIdCache;
 import org.jasig.portal.events.aggr.AggregationInterval;
 import org.jasig.portal.events.aggr.BaseAggregationImpl;
-import org.jasig.portal.events.aggr.BaseGroupedAggregationDiscriminator;
 import org.jasig.portal.events.aggr.DateDimension;
 import org.jasig.portal.events.aggr.TimeDimension;
 import org.jasig.portal.events.aggr.UniqueStrings;
 import org.jasig.portal.events.aggr.groups.AggregatedGroupMapping;
-import org.jasig.portal.events.aggr.login.LoginAggregationDiscriminator;
-import org.jasig.portal.events.aggr.login.LoginAggregationDiscriminatorImpl;
 
 /**
  * @author Eric Dalquist
@@ -76,7 +73,7 @@ import org.jasig.portal.events.aggr.login.LoginAggregationDiscriminatorImpl;
                 @Index(name = "IDX_UP_CONC_USER_INTRVL", columnNames = { "AGGR_INTERVAL" }),
                 @Index(name = "IDX_UP_CONC_USER_GRP", columnNames = { "AGGR_GROUP_ID" })
         })
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.concuser.ConcurrentUserAggregationImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public final class ConcurrentUserAggregationImpl 

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/dao/jpa/DateDimensionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/dao/jpa/DateDimensionImpl.java
@@ -61,7 +61,7 @@ import org.joda.time.LocalDate;
         pkColumnValue="UP_DATE_DIMENSION_PROP",
         allocationSize=1
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.dao.jpa.DateDimensionImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class DateDimensionImpl implements DateDimension, Serializable {

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/dao/jpa/EventAggregatorStatusImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/dao/jpa/EventAggregatorStatusImpl.java
@@ -44,7 +44,7 @@ import org.joda.time.DateTime;
 @Table(name = "UP_EVENT_AGGR_STATUS")
 @SequenceGenerator(name = "UP_EVENT_AGGR_STATUS_GEN", sequenceName = "UP_EVENT_AGGR_STATUS_SEQ", allocationSize = 10)
 @TableGenerator(name = "UP_EVENT_AGGR_STATUS_GEN", pkColumnValue = "UP_EVENT_AGGR_STATUS", allocationSize = 10)
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.dao.jpa.EventAggregatorStatusImpl-NaturalId")
 class EventAggregatorStatusImpl implements IEventAggregatorStatus {
     
     @Id

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/dao/jpa/TimeDimensionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/dao/jpa/TimeDimensionImpl.java
@@ -62,7 +62,7 @@ import org.joda.time.LocalTime;
         allocationSize=1
     )
 @Immutable
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.dao.jpa.TimeDimensionImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 public final class TimeDimensionImpl implements TimeDimension, Serializable {

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/groups/AggregatedGroupMappingImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/groups/AggregatedGroupMappingImpl.java
@@ -73,7 +73,7 @@ import org.hibernate.annotations.NaturalIdCache;
         allocationSize=10
     )
 @Immutable
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.groups.AggregatedGroupMappingImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 public final class AggregatedGroupMappingImpl implements AggregatedGroupMapping, Serializable {

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/login/LoginAggregationImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/login/LoginAggregationImpl.java
@@ -73,7 +73,7 @@ import org.jasig.portal.events.aggr.groups.AggregatedGroupMapping;
                 @Index(name = "IDX_UP_LOGIN_EVENT_INTRVL", columnNames = { "AGGR_INTERVAL" }),
                 @Index(name = "IDX_UP_LOGIN_EVENT_GRP", columnNames = { "AGGR_GROUP_ID" })
         })
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.login.LoginAggregationImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public final class LoginAggregationImpl 

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/portletexec/PortletExecutionAggregationImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/portletexec/PortletExecutionAggregationImpl.java
@@ -76,7 +76,7 @@ import org.jasig.portal.events.aggr.portlets.AggregatedPortletMappingImpl;
                 @Index(name = "IDX_UP_PLT_EXEC_INTRVL", columnNames = { "AGGR_INTERVAL" }),
                 @Index(name = "IDX_UP_PLT_EXEC_GRP", columnNames = { "AGGR_GROUP_ID" })
         })
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.portletexec.PortletExecutionAggregationImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public final class PortletExecutionAggregationImpl 

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/portletlayout/PortletLayoutAggregationImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/portletlayout/PortletLayoutAggregationImpl.java
@@ -18,18 +18,7 @@
  */
 package org.jasig.portal.events.aggr.portletlayout;
 
-import org.apache.commons.lang.Validate;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Index;
-import org.hibernate.annotations.NaturalId;
-import org.hibernate.annotations.NaturalIdCache;
-import org.jasig.portal.events.aggr.AggregationInterval;
-import org.jasig.portal.events.aggr.BaseAggregationImpl;
-import org.jasig.portal.events.aggr.DateDimension;
-import org.jasig.portal.events.aggr.TimeDimension;
-import org.jasig.portal.events.aggr.groups.AggregatedGroupMapping;
-import org.jasig.portal.events.aggr.portlets.AggregatedPortletMapping;
-import org.jasig.portal.events.aggr.portlets.AggregatedPortletMappingImpl;
+import java.io.Serializable;
 
 import javax.persistence.Cacheable;
 import javax.persistence.Column;
@@ -44,7 +33,19 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.TableGenerator;
 import javax.persistence.Transient;
-import java.io.Serializable;
+
+import org.apache.commons.lang.Validate;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.NaturalId;
+import org.hibernate.annotations.NaturalIdCache;
+import org.jasig.portal.events.aggr.AggregationInterval;
+import org.jasig.portal.events.aggr.BaseAggregationImpl;
+import org.jasig.portal.events.aggr.DateDimension;
+import org.jasig.portal.events.aggr.TimeDimension;
+import org.jasig.portal.events.aggr.groups.AggregatedGroupMapping;
+import org.jasig.portal.events.aggr.portlets.AggregatedPortletMapping;
+import org.jasig.portal.events.aggr.portlets.AggregatedPortletMappingImpl;
 
 /**
  * @author Chris Waymire <cwaymire@unicon.net>
@@ -70,7 +71,7 @@ import java.io.Serializable;
                 @Index(name = "IDX_UP_PORTLET_LAYOUT_INTRVL", columnNames = { "AGGR_INTERVAL" }),
                 @Index(name = "IDX_UP_PORTLET_LAYOUT_GRP", columnNames = { "AGGR_GROUP_ID" })
         })
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.portletlayout.PortletLayoutAggregationImpl-NaturalId")
 @Cacheable
 @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public final class PortletLayoutAggregationImpl

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/portlets/AggregatedPortletMappingImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/portlets/AggregatedPortletMappingImpl.java
@@ -51,7 +51,7 @@ import org.hibernate.annotations.Type;
         allocationSize=10
     )
 @Immutable
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.portlets.AggregatedPortletMappingImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 public final class AggregatedPortletMappingImpl implements AggregatedPortletMapping, Serializable {

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/session/EventSessionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/session/EventSessionImpl.java
@@ -73,7 +73,7 @@ import org.joda.time.DateTime;
         appliesTo = "UP_EVENT_SESSION",
         indexes = @Index(name = "IDX_UP_EVENT_SESSION_DATE", columnNames = { "LAST_ACCESSED" })
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.session.EventSessionImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public class EventSessionImpl implements EventSession, Serializable {

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/tabrender/TabRenderAggregationImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/tabrender/TabRenderAggregationImpl.java
@@ -73,7 +73,7 @@ import org.jasig.portal.events.aggr.tabs.AggregatedTabMappingImpl;
                 @Index(name = "IDX_UP_TAB_REND_INTRVL", columnNames = { "AGGR_INTERVAL" }),
                 @Index(name = "IDX_UP_TAB_REND_GRP", columnNames = { "AGGR_GROUP_ID" })
         })
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.tabrender.TabRenderAggregationImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
 public final class TabRenderAggregationImpl

--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/tabs/AggregatedTabMappingImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/tabs/AggregatedTabMappingImpl.java
@@ -50,7 +50,7 @@ import org.hibernate.annotations.NaturalIdCache;
         allocationSize=10
     )
 @Immutable
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.events.aggr.tabs.AggregatedTabMappingImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 public final class AggregatedTabMappingImpl implements AggregatedTabMapping, Serializable {

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/jpa/PersonAttributesGroupDefinitionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/jpa/PersonAttributesGroupDefinitionImpl.java
@@ -65,7 +65,7 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestGroupDefinitio
         pkColumnValue="UP_PAGS_GROUP",
         allocationSize=5
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.groups.pags.dao.jpa.PersonAttributesGroupDefinitionImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class PersonAttributesGroupDefinitionImpl implements IPersonAttributesGroupDefinition {

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/jpa/PersonAttributesGroupTestDefinitionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/jpa/PersonAttributesGroupTestDefinitionImpl.java
@@ -58,7 +58,7 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestGroupDefinitio
         pkColumnValue="UP_PAGS_TEST",
         allocationSize=5
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.groups.pags.dao.jpa.PersonAttributesGroupTestDefinitionImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class PersonAttributesGroupTestDefinitionImpl implements IPersonAttributesGroupTestDefinition {

--- a/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/jpa/PersonAttributesGroupTestGroupDefinitionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/groups/pags/dao/jpa/PersonAttributesGroupTestGroupDefinitionImpl.java
@@ -64,7 +64,7 @@ import org.jasig.portal.groups.pags.dao.IPersonAttributesGroupTestGroupDefinitio
         pkColumnValue="UP_PAGS_TEST_GROUP",
         allocationSize=5
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.groups.pags.dao.jpa.PersonAttributesGroupTestGroupDefinitionImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class PersonAttributesGroupTestGroupDefinitionImpl implements IPersonAttributesGroupTestGroupDefinition {

--- a/uportal-war/src/main/java/org/jasig/portal/layout/dao/jpa/StylesheetDescriptorImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/dao/jpa/StylesheetDescriptorImpl.java
@@ -77,7 +77,7 @@ import org.jasig.portal.layout.om.IStylesheetUserPreferences;
         pkColumnValue="UP_SS_DESC",
         allocationSize=5
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.layout.dao.jpa.StylesheetDescriptorImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class StylesheetDescriptorImpl implements IStylesheetDescriptor {

--- a/uportal-war/src/main/java/org/jasig/portal/permission/dao/jpa/PermissionOwnerImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/permission/dao/jpa/PermissionOwnerImpl.java
@@ -67,7 +67,7 @@ import org.jasig.portal.permission.IPermissionOwner;
         pkColumnValue="UP_PERMISSION_OWNER",
         allocationSize=1
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.permission.dao.jpa.PermissionOwnerImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 class PermissionOwnerImpl implements IPermissionOwner, Serializable {

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortalCookieImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortalCookieImpl.java
@@ -72,7 +72,7 @@ import org.joda.time.DateTime;
         appliesTo = "UP_PORTAL_COOKIES",
         indexes = @Index(name = "IDX_UP_PRTL_CK_EXP", columnNames = { "EXPIRES" })
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.portlet.dao.jpa.PortalCookieImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 class PortalCookieImpl implements IPortalCookie {

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortletDefinitionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortletDefinitionImpl.java
@@ -89,7 +89,7 @@ import org.jasig.portal.portlet.om.PortletLifecycleState;
         pkColumnValue="UP_PORTLET_DEF",
         allocationSize=5
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.portlet.dao.jpa.PortletDefinitionImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 class PortletDefinitionImpl implements IPortletDefinition {

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortletTypeImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortletTypeImpl.java
@@ -61,7 +61,7 @@ import org.jasig.portal.portlet.om.IPortletType;
         pkColumnValue="UP_PORTLET_TYPE",
         allocationSize=1
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.portlet.dao.jpa.PortletTypeImpl-NaturalId")
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 public class PortletTypeImpl implements Serializable, IPortletType {

--- a/uportal-war/src/main/java/org/jasig/portal/version/dao/jpa/VersionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/version/dao/jpa/VersionImpl.java
@@ -44,7 +44,7 @@ import org.jasig.portal.version.om.Version;
         pkColumnValue="UP_VERSION",
         allocationSize=1
     )
-@NaturalIdCache
+@NaturalIdCache(region = "org.jasig.portal.version.dao.jpa.VersionImpl-NaturalId")
 class VersionImpl extends AbstractVersion {
     private static final long serialVersionUID = 1L;
 

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -43,6 +43,50 @@
     <cacheManagerPeerProviderFactory
         class="net.sf.ehcache.distribution.jgroups.JGroupsCacheManagerPeerProviderFactory"
         properties="file=properties/jgroups.xml" />
+
+    <!--
+     | Start of RMI Replicated Caching for CAS ClearPass in uPortal.
+     |
+     | The RMI Peer provider/listener is required for using CAS ClearPass in a clustered uPortal
+     | environment.  If you are not using CAS ClearPass, or if you don't have your uPortal servers clustered
+     | you do not need RMI Replicated Caching.  Either the automatic or manual peer discovery peer provide factory
+     | must be uncommented, along with the RMI Peer Listener.
+     +-->
+
+    <!--
+     | RMI Replicated Caching Automatic Peer Discovery.  If it works in your network environment, it is a simpler
+     | configuration.
+     | Need to verify it with someone who can test it though. Couldn't on my home network (see UP-4108 notes).
+     | When testing it, suggest enabling debug logging as indicated in UP-4108.
+     +-->
+     <!--
+     <cacheManagerPeerProviderFactory
+        class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
+        properties="peerDiscovery=automatic, multicastGroupAddress=230.0.0.1, multicastGroupPort=4446, timeToLive=32"
+        propertySeparator="," />
+     -->
+
+    <!--
+     | RMI Replicated Caching Manual Peer Discovery.  Use if automatic does not work for you or you don't want to
+     | allow multicast on your network.  You must also set the IP addresses of the machines in the uPortal cluster
+     | in the filters/*.properties files.
+     +-->
+    <!--
+    <cacheManagerPeerProviderFactory
+        class="net.sf.ehcache.distribution.RMICacheManagerPeerProviderFactory"
+        properties="peerDiscovery=manual,rmiUrls=${environment.build.cas.clearpass.cache.rmi.urls}" />
+    -->
+    <!--
+     | Required if using Manual or Automatic RMI Replicated Caching Peer Discovery for CAS ClearPass in clustered
+     | uPortal environment.
+     +-->
+    <!--
+    <cacheManagerPeerListenerFactory
+        class="net.sf.ehcache.distribution.RMICacheManagerPeerListenerFactory"
+        properties="port=${environment.build.cas.clearpass.cache.rmi.listenerPort}" />
+    -->
+
+    <!-- End of RMI Replicated Caching for CAS ClearPass in uPortal. -->
     
     <defaultCache eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="0" timeToLiveSeconds="600" memoryStoreEvictionPolicy="LRU" statistics="true" />
@@ -489,7 +533,7 @@
         timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" />
     
     <!-- Only ID Cached -->
-    <cache name="org.jasig.portal.concurrency.locking.ClusterMutex##NaturalId"
+    <cache name="org.jasig.portal.concurrency.locking.ClusterMutex-NaturalId"
         eternal="false" maxElementsInMemory="100" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory
@@ -499,7 +543,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="org.jasig.portal.version.dao.jpa.VersionImpl##NaturalId"
+    <cache name="org.jasig.portal.version.dao.jpa.VersionImpl-NaturalId"
         eternal="false" maxElementsInMemory="100" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory
@@ -574,7 +618,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="org.jasig.portal.layout.dao.jpa.StylesheetDescriptorImpl##NaturalId"
+    <cache name="org.jasig.portal.layout.dao.jpa.StylesheetDescriptorImpl-NaturalId"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory
@@ -872,7 +916,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="org.jasig.portal.permission.dao.jpa.PermissionOwnerImpl##NaturalId"
+    <cache name="org.jasig.portal.permission.dao.jpa.PermissionOwnerImpl-NaturalId"
         eternal="false" maxElementsInMemory="100" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory
@@ -983,7 +1027,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="org.jasig.portal.portlet.dao.jpa.PortalCookieImpl##NaturalId"
+    <cache name="org.jasig.portal.portlet.dao.jpa.PortalCookieImpl-NaturalId"
         eternal="false" maxElementsInMemory="2500" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="900" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory
@@ -1039,7 +1083,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="org.jasig.portal.portlet.dao.jpa.PortletDefinitionImpl##NaturalId"
+    <cache name="org.jasig.portal.portlet.dao.jpa.PortletDefinitionImpl-NaturalId"
         eternal="false" maxElementsInMemory="1000" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="0" timeToLiveSeconds="21600" memoryStoreEvictionPolicy="LFU" statistics="true" >
         <cacheEventListenerFactory
@@ -1188,7 +1232,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="org.jasig.portal.portlet.dao.jpa.PortletTypeImpl##NaturalId"
+    <cache name="org.jasig.portal.portlet.dao.jpa.PortletTypeImpl-NaturalId"
         eternal="false" maxElementsInMemory="250" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true" >
         <cacheEventListenerFactory
@@ -1424,7 +1468,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.dao.jpa.DateDimensionImpl##NaturalId" 
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.dao.jpa.DateDimensionImpl-NaturalId" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="3660" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true">
         <cacheEventListenerFactory
@@ -1459,7 +1503,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.dao.jpa.TimeDimensionImpl##NaturalId" 
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.dao.jpa.TimeDimensionImpl-NaturalId" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="1440" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true">
         <cacheEventListenerFactory
@@ -1481,7 +1525,7 @@
     </cache>
         
     <!-- NOT CACHED: org.jasig.portal.events.aggr.dao.jpa.EventAggregatorStatusImpl -->
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.dao.jpa.EventAggregatorStatusImpl##NaturalId" 
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.dao.jpa.EventAggregatorStatusImpl-NaturalId" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="10" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true">
         <cacheEventListenerFactory
@@ -1507,7 +1551,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.groups.AggregatedGroupMappingImpl##NaturalId" 
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.groups.AggregatedGroupMappingImpl-NaturalId" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="1000" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true">
         <cacheEventListenerFactory
@@ -1543,7 +1587,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.portlets.AggregatedPortletMappingImpl##NaturalId" 
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.portlets.AggregatedPortletMappingImpl-NaturalId" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="1000" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true">
         <cacheEventListenerFactory
@@ -1579,7 +1623,7 @@
                 replicateUpdates=true, replicateUpdatesViaCopy=false,
                 replicateRemovals=true "/>
     </cache>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.tabs.AggregatedTabMappingImpl##NaturalId" 
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.tabs.AggregatedTabMappingImpl-NaturalId" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="500" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true">
         <cacheEventListenerFactory
@@ -1653,7 +1697,7 @@
     <cache name="AggrEvents.org.jasig.portal.events.aggr.login.LoginAggregationImpl" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="5000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.login.LoginAggregationImpl##NaturalId"
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.login.LoginAggregationImpl-NaturalId"
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="5000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
     <cache name="AggrEvents.org.jasig.portal.events.aggr.login.LoginAggregationImpl.Query" 
@@ -1667,7 +1711,7 @@
     <cache name="AggrEvents.org.jasig.portal.events.aggr.concuser.ConcurrentUserAggregationImpl" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="5000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.concuser.ConcurrentUserAggregationImpl##NaturalId"
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.concuser.ConcurrentUserAggregationImpl-NaturalId"
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="5000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
     <cache name="AggrEvents.org.jasig.portal.events.aggr.concuser.ConcurrentUserAggregationImpl.Query" 
@@ -1681,7 +1725,7 @@
     <cache name="AggrEvents.org.jasig.portal.events.aggr.tabrender.TabRenderAggregationImpl" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="10000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.tabrender.TabRenderAggregationImpl##NaturalId"
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.tabrender.TabRenderAggregationImpl-NaturalId"
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="10000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
     <cache name="AggrEvents.org.jasig.portal.events.aggr.tabrender.TabRenderAggregationImpl.Query" 
@@ -1695,7 +1739,7 @@
     <cache name="AggrEvents.org.jasig.portal.events.aggr.portletexec.PortletExecutionAggregationImpl" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="100000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.portletexec.PortletExecutionAggregationImpl##NaturalId"
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.portletexec.PortletExecutionAggregationImpl-NaturalId"
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="100000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
     <cache name="AggrEvents.org.jasig.portal.events.aggr.portletexec.PortletExecutionAggregationImpl.Query" 
@@ -1709,7 +1753,7 @@
     <cache name="AggrEvents.org.jasig.portal.events.aggr.session.EventSessionImpl" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="100000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
-    <cache name="AggrEvents.org.jasig.portal.events.aggr.session.EventSessionImpl##NaturalId" 
+    <cache name="AggrEvents.org.jasig.portal.events.aggr.session.EventSessionImpl-NaturalId" 
         eternal="false" overflowToDisk="false" diskPersistent="false"
         maxElementsInMemory="100000" timeToIdleSeconds="600" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
     <cache name="AggrEvents.org.jasig.portal.events.aggr.session.EventSessionImpl.groupMappings" 
@@ -1750,7 +1794,7 @@
            maxElementsInMemory="10000" timeToIdleSeconds="600" timeToLiveSeconds="0"
            memoryStoreEvictionPolicy="LRU" statistics="true">
         <cacheEventListenerFactory
-            class="net.sf.ehcache.distribution.jgroups.JGroupsCacheReplicatorFactory"
+            class="net.sf.ehcache.distribution.RMICacheReplicatorFactory"
             properties="replicateAsynchronously=false,
                 replicatePuts=true,
                 replicateUpdates=true, replicateUpdatesViaCopy=true,


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4108

Allows using RMI Replicated Caching with uPortal for CAS ClearPass in Clustered environment so a CAS PGTIOU->PGT ticket that is sent to another uPortal server in the cluster will have the object replicated into the cache of all servers before the server the user is on attempts to look up the PGT from the PGTIOU.
- Changes NaturalIdQuery to specifically name cache to use because auto-generated cachename is {entity-name}##NaturalId and RMI URLs don't allow # characters (even though the ##NaturalId caches were not being replicated, the RMI Caching code threw exceptions)
- Added configuration to filters files and ehcache.xml
