### PR TITLE
UP-4106 Enforce CONFIG permission.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlet/rendering/IPortletRenderer.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/rendering/IPortletRenderer.java
@@ -107,6 +107,8 @@ public interface IPortletRenderer {
      * @param portletWindowId Portlet to target with the action
      * @param httpServletRequest The portal's request
      * @param httpServletResponse The portal's response (nothing will be written to the response)
+     * @throws org.jasig.portal.AuthorizationException if the requesting user lacks permission to invoke
+     * the portlet window (e.g. due to its having a forbidden portlet mode)
      */
     public long doAction(IPortletWindowId portletWindowId, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse);
     
@@ -116,6 +118,8 @@ public interface IPortletRenderer {
      * @param portletWindowId Portlet to target with the action
      * @param httpServletRequest The portal's request
      * @param httpServletResponse The portal's response (nothing will be written to the response)
+     * @throws org.jasig.portal.AuthorizationException if the requesting user lacks permission to invoke
+     * the portlet window (e.g. due to its having a forbidden portlet mode)
      */
     public long doEvent(IPortletWindowId portletWindowId, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Event event);
     
@@ -126,6 +130,8 @@ public interface IPortletRenderer {
      * @param httpServletRequest The portal's request
      * @param httpServletResponse The portal's response (nothing will be written to the response)
      * @param portletOutputHandler The output handler to write to
+     * @throws org.jasig.portal.AuthorizationException if the requesting user lacks permission to invoke
+     * the portlet window (e.g. due to its having a forbidden portlet mode)
      */
     public PortletRenderResult doRenderMarkup(IPortletWindowId portletWindowId, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, PortletOutputHandler portletOutputHandler) throws IOException;
     
@@ -136,6 +142,8 @@ public interface IPortletRenderer {
      * @param httpServletRequest The portal's request
      * @param httpServletResponse The portal's response (nothing will be written to the response)
      * @param portletOutputHandler The output handler to write to
+     * @throws org.jasig.portal.AuthorizationException if the requesting user lacks permission to invoke
+     * the portlet window (e.g. due to its having a forbidden portlet mode)
      */
     public PortletRenderResult doRenderHeader(IPortletWindowId portletWindowId, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, PortletOutputHandler portletOutputHandler) throws IOException;
     
@@ -147,6 +155,8 @@ public interface IPortletRenderer {
      * @param httpServletResponse The portal's response (nothing will be written to the response)
      * @param portletOutputHandler The output handler to write to
      * @return The execution time for serving the resource
+     * @throws org.jasig.portal.AuthorizationException if the requesting user lacks permission to invoke
+     * the portlet window (e.g. due to its having a forbidden portlet mode)
      */
     public long doServeResource(IPortletWindowId portletWindowId, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, PortletResourceOutputHandler portletOutputHandler) throws IOException;
     


### PR DESCRIPTION
Addresses CVE-2014-3417 :relieved:  .

This is the same fix as that on `rel-4.0-patches` ( https://github.com/Jasig/uPortal/commit/26aa4b4f2f5d1c3d95ad38b5bb9e68933c0da6d7 ) and included in uPortal `4.0.13.1` ( https://github.com/Jasig/uPortal/commit/de2acd1d613980d0540df8e2f7babf0e6281dc96 ) , tweaked to
- Use the Commons Lang 3 available in `master`
- Use the slf4j available in `master`
- Get the authorization exception name right in the `enforceConfigPermission` JavaDoc

Proffering as pull request against `master` so that this fix implementation, now that the cat's out of the bag, has an opportunity for review.  This should definitely be reviewed to merge before cutting 4.1 GA.
