### PR TITLE
UP-4131 Add caching, SpEL expressions to SqlQuery portlet

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/io/xml/portlet/PortletDefinitionImporterExporter.java
@@ -150,7 +150,7 @@ public class PortletDefinitionImporterExporter
             }
             
             if (category == null) {
-                throw new IllegalArgumentException("No category '" + categoryName + "' found when importing porltet: " + portletRep.getFname());
+                throw new IllegalArgumentException("No category '" + categoryName + "' found when importing portlet: " + portletRep.getFname());
             }
             
             categories.add(category);
@@ -168,7 +168,7 @@ public class PortletDefinitionImporterExporter
             }
             
             if (group == null) {
-                throw new IllegalArgumentException("No group '" + groupName + "' found when importing porltet: " + portletRep.getFname());
+                throw new IllegalArgumentException("No group '" + groupName + "' found when importing portlet: " + portletRep.getFname());
             }
             
             groups.add(group);

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/IPortletSpELService.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/IPortletSpELService.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.portlet;
+
+import javax.portlet.PortletRequest;
+
+import org.springframework.expression.EvaluationException;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ParseException;
+
+/**
+ * IPortletSpELService provides an interface for parsing strings using the Spring expression language.
+ * Strings are assumed to be a potential mixture of SpEL expressions contained inside a ${ } and text string
+ * content.  For example, a portal-relative URL path might be formatted as
+ * ${request.contextPath}/my/path.
+ *
+ * Possible spring attribute values are:<ul>
+ *     <li>request - portlet Request</li>
+ *     <li>userInfo - map of User Info available to the portlet</li>
+ *     <li>@beanName - bean in spring context</li>
+ * </ul>
+ *
+ * @author James Wennmacher, jwennmacher@unicon.net
+ */
+
+public interface IPortletSpELService {
+
+    /**
+     * Parse the supplied string by replacing any ${ } blocks with the SpEL-evaluated value.
+     *
+     * @param expressionString  string to be evaluated
+     * @param request portlet request
+     * @return evaluated string
+     */
+    String parseString(String expressionString, PortletRequest request)  throws EvaluationException;
+
+    /**
+     * Parse the supplied string by replacing any ${ } blocks with the SpEL-evaluated value, returning the
+     * desired type if possible.
+     *
+     * @param expressionString  string to be evaluated
+     * @param request portlet request
+     * @return evaluated object
+     * @exception EvaluationException
+     */
+    <T> T getValue(String expressionString, PortletRequest request, Class<T> desiredResultType) throws EvaluationException;
+
+    /**
+     * Returns a SpEL Expression using the standard Parsing Context (uses ${ }).  Allows you to supply your own
+     * {@link org.springframework.expression.spel.support.StandardEvaluationContext} to evaluate the expression
+     * against any objects you want.  Refer to SpEL API or review the code in
+     * {@link org.jasig.portal.portlet.PortletSpELServiceImpl}.
+     * @param expressionString string to be evaluated
+     * @return SpEL Expression
+     * @throws ParseException Error in expression string format
+     */
+    Expression parseExpression(String expressionString) throws ParseException;
+}

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/PortletSpELServiceImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/PortletSpELServiceImpl.java
@@ -1,0 +1,187 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.portlet;
+
+import java.util.Map;
+
+import javax.portlet.PortletRequest;
+
+import net.sf.ehcache.Ehcache;
+import net.sf.ehcache.Element;
+import org.apache.commons.lang.Validate;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.expression.BeanResolver;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.ParseException;
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.portlet.context.PortletWebRequest;
+
+/**
+ * PortletSpELServiceImpl provides the default implementation of IPortletSpELService.
+ * 
+ * @author James Wennmacher, jwennmacher@unicon.net (code based on PortalSpELServiceImpl by Jen Bourey)
+ */
+@Service
+public class PortletSpELServiceImpl implements BeanFactoryAware, IPortletSpELService {
+    protected final Log logger = LogFactory.getLog(this.getClass());
+    
+    private ExpressionParser expressionParser = new SpelExpressionParser();
+    private Ehcache expressionCache;
+    private BeanResolver beanResolver;
+
+    public void setExpressionParser(ExpressionParser expressionParser) {
+        Validate.notNull(expressionParser);
+        this.expressionParser = expressionParser;
+    }
+
+    @Autowired
+    public void setExpressionCache(@Qualifier("portletSpELExpressionCache") Ehcache expressionCache) {
+        this.expressionCache = expressionCache;
+    }
+    
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
+        this.beanResolver = new BeanFactoryResolver(beanFactory);
+    }
+
+    // Primary method used assuming all defaults.
+    @Override
+    public String parseString(String expressionString, PortletRequest request) {
+        return getValue(expressionString, request, String.class);
+    }
+
+    @Override
+    public <T> T getValue(String expressionString, PortletRequest request, Class<T> desiredResultType) {
+        final Expression expression = parseExpression(expressionString);
+        final EvaluationContext evaluationContext = getEvaluationContext(request);
+        return expression.getValue(evaluationContext, desiredResultType);
+    }
+
+    @Override
+    public Expression parseExpression(String expressionString) throws ParseException {
+        if (this.expressionCache == null) {
+            return parseExpression(expressionString, TemplateParserContext.INSTANCE);
+        }
+
+        Element element = this.expressionCache.get(expressionString);
+        if (element != null) {
+            return (Expression)element.getObjectValue();
+        }
+
+        final Expression expression = parseExpression(expressionString, TemplateParserContext.INSTANCE);
+
+        element = new Element(expressionString, expression);
+        this.expressionCache.put(element);
+
+        return expression;
+    }
+
+    private Expression parseExpression(String expressionString, ParserContext parserContext) throws ParseException {
+        if (parserContext == null) {
+            return this.expressionParser.parseExpression(expressionString);
+        }
+
+        return this.expressionParser.parseExpression(expressionString, parserContext);
+    }
+
+    /**
+     * Return a SpEL evaluation context for the supplied portlet request.
+     *
+     * @param request PortletRequest
+     * @return SpEL evaluation context for the supplied portlet request
+     */
+    protected EvaluationContext getEvaluationContext(PortletRequest request) {
+        Map<String, String> userInfo = (Map<String, String>) request.getAttribute(PortletRequest.USER_INFO);
+        final SpELEnvironmentRoot root = new SpELEnvironmentRoot(new PortletWebRequest(request), userInfo);
+        final StandardEvaluationContext context = new StandardEvaluationContext(root);
+        // Allows for @myBeanName replacements
+        context.setBeanResolver(this.beanResolver);
+        return context;
+    }
+
+    /**
+     * Limited-use POJO representing the root of a SpEL environment.  At the current moment, we're only using
+     * the request object and user info in the evaluation context.  Can add additional objects in the future.
+     */
+    @SuppressWarnings("unused")
+    private static class SpELEnvironmentRoot {
+
+        private final WebRequest request;
+        private final Map<String,String> userInfo;
+
+        /**
+         * Create a new SpEL environment root for use in a SpEL evaluation
+         * context.
+         *
+         * @param request  web request
+         */
+        private SpELEnvironmentRoot(WebRequest request, Map<String,String>userInfo) {
+            this.request = request;
+            this.userInfo = userInfo;
+        }
+
+        /**
+         * Get the request associated with this environment root.
+         */
+        public WebRequest getRequest() {
+            return request;
+        }
+
+        /**
+         * User attributes associated with the person in this request.
+         * @return userInfo
+         */
+        public Map<String, String> getUserInfo() {
+            return userInfo;
+        }
+    }
+
+    public static class TemplateParserContext implements ParserContext {
+        public static final TemplateParserContext INSTANCE = new TemplateParserContext();
+    
+        @Override
+        public String getExpressionPrefix() {
+            return "${";
+        }
+
+        @Override
+        public String getExpressionSuffix() {
+            return "}";
+        }
+
+        @Override
+        public boolean isTemplate() {
+            return true;
+        }
+    }
+}

--- a/uportal-war/src/main/java/org/jasig/portal/portlets/sqlquery/SqlQueryConfigForm.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/sqlquery/SqlQueryConfigForm.java
@@ -27,6 +27,10 @@ public class SqlQueryConfigForm {
 	
 	private String viewName;
 
+    private String cacheName;
+
+    private Boolean perUserCaching;
+
 	public String getSqlQuery() {
 		return this.sqlQuery;
 	}
@@ -50,7 +54,20 @@ public class SqlQueryConfigForm {
 	public void setViewName(String viewName) {
 		this.viewName = viewName;
 	}
-	
-	
-	
+
+    public String getCacheName() {
+        return cacheName;
+    }
+
+    public void setCacheName(String cacheName) {
+        this.cacheName = cacheName;
+    }
+
+    public Boolean getPerUserCaching() {
+        return perUserCaching;
+    }
+
+    public void setPerUserCaching(Boolean perUserCaching) {
+        this.perUserCaching = perUserCaching;
+    }
 }

--- a/uportal-war/src/main/java/org/jasig/portal/portlets/sqlquery/SqlQueryConfigurationController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/sqlquery/SqlQueryConfigurationController.java
@@ -19,15 +19,25 @@
 
 package org.jasig.portal.portlets.sqlquery;
 
+import java.io.IOException;
+
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.PortletMode;
+import javax.portlet.PortletModeException;
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
+import javax.portlet.ReadOnlyException;
+import javax.portlet.ValidatorException;
 
+import org.apache.commons.lang.StringUtils;
 import org.jasig.portal.jpa.BasePortalJpaDao;
-import org.springframework.validation.BindException;
-import org.springframework.web.portlet.mvc.SimpleFormController;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 /**
  * Handles CONFIG mode for the SQL query portlet.
@@ -35,36 +45,50 @@ import org.springframework.web.portlet.mvc.SimpleFormController;
  * @author Jen Bourey, jbourey@unicon.net
  * @version $Revision$
  */
-public class SqlQueryConfigurationController extends SimpleFormController {
+@Controller
+@RequestMapping("CONFIG")
+public class SqlQueryConfigurationController {
 	
 	private String defaultDataSource = BasePortalJpaDao.PERSISTENCE_UNIT_NAME;
 	private String defaultView = "jsp/SqlQuery/results";
 
-	@Override
-	protected void onSubmitAction(ActionRequest request,
-			ActionResponse response, Object command, BindException errors)
-			throws Exception {
-		SqlQueryConfigForm form = (SqlQueryConfigForm) command;
+    @RequestMapping
+    public String getAccountFormView(PortletRequest request, Model model) {
+        model.addAttribute("form", getConfigurationForm(request));
+        return "jsp/SqlQuery/config";
+    }
 
-		PortletPreferences prefs = request.getPreferences();
-		prefs.setValue(SqlQueryPortletController.DATASOURCE_BEAN_NAME_PARAM_NAME, form.getDataSource());
-		prefs.setValue(SqlQueryPortletController.SQL_QUERY_PARAM_NAME, form.getSqlQuery());
-		prefs.setValue(SqlQueryPortletController.VIEW_PARAM_NAME, form.getViewName());
-		prefs.store();
+    @RequestMapping(params = "action=updateConfiguration")
+    public void saveAccountConfiguration(ActionRequest request, ActionResponse response,
+                                         @ModelAttribute("form") SqlQueryConfigForm form,
+                                         BindingResult errors,
+                                         @RequestParam(value="Save", required=false) String save)
+            throws PortletModeException, IOException, ValidatorException, ReadOnlyException {
+
+        if (StringUtils.isNotBlank(save)) {
+
+            PortletPreferences prefs = request.getPreferences();
+            prefs.setValue(SqlQueryPortletController.DATASOURCE_BEAN_NAME_PARAM_NAME, form.getDataSource());
+            prefs.setValue(SqlQueryPortletController.SQL_QUERY_PARAM_NAME, form.getSqlQuery());
+            prefs.setValue(SqlQueryPortletController.VIEW_PARAM_NAME, form.getViewName());
+            prefs.setValue(SqlQueryPortletController.PREF_CACHE_NAME,form.getCacheName());
+            prefs.setValue(SqlQueryPortletController.PREF_CACHE_PER_USER, form.getPerUserCaching().toString());
+            prefs.store();
+        }
 		
 		response.setPortletMode(PortletMode.VIEW);
 
 	}
 
-	@Override
-	protected Object formBackingObject(PortletRequest request) throws Exception {
-		
+    public SqlQueryConfigForm getConfigurationForm(PortletRequest request) {
 		PortletPreferences prefs = request.getPreferences();
 		SqlQueryConfigForm form = new SqlQueryConfigForm();
 		
 		form.setDataSource(prefs.getValue(SqlQueryPortletController.DATASOURCE_BEAN_NAME_PARAM_NAME, defaultDataSource));
 		form.setViewName(prefs.getValue(SqlQueryPortletController.VIEW_PARAM_NAME, defaultView));
 		form.setSqlQuery(prefs.getValue(SqlQueryPortletController.SQL_QUERY_PARAM_NAME, ""));
+        form.setCacheName(prefs.getValue(SqlQueryPortletController.PREF_CACHE_NAME, SqlQueryPortletController.DEFAULT_CACHE_NAME));
+        form.setPerUserCaching(Boolean.valueOf(prefs.getValue(SqlQueryPortletController.PREF_CACHE_PER_USER, "true")));
 		
 		return form;
 	}

--- a/uportal-war/src/main/java/org/jasig/portal/portlets/sqlquery/SqlQueryPortletController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/sqlquery/SqlQueryPortletController.java
@@ -23,38 +23,58 @@ import java.util.List;
 import java.util.Map;
 
 import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 import javax.sql.DataSource;
 
+import net.sf.ehcache.Cache;
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.Element;
+import org.apache.commons.lang.StringUtils;
 import org.jasig.portal.jpa.BasePortalJpaDao;
+import org.jasig.portal.portlet.IPortletSpELService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.ColumnMapRowMapper;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.portlet.ModelAndView;
 import org.springframework.web.portlet.mvc.AbstractController;
 
 /**
- * This portlet executes a (configurable) SQL query against a (configurable)
- * DataSource accessed via the Spring application context, translates the 
- * ResultSet into a collection of row Map objects, and feeds that object to 
- * a JSP page.
+ * This portlet executes a (configurable) SQL query against a (configurable) DataSource accessed via the Spring
+ * application context, translates the ResultSet into a collection of row Map objects, and feeds that object to
+ * a (configurable) JSP page.
+ *
+ * The SQL Query can substitute attributes from the request, user attributes, or spring beans by using Spring
+ * Expression Language (SpEL) patterns against the request object, user attributes, or a bean (@MyBeanName).
+ * It's recommended to provide a default value using the Elvis operator (?:) in case the attribute is undefined
+ * which results in no value. Some example queries using SpEL are:
+ * <pre>
+ * select * from EB_CONTACT_TABLE where pidm = ${userInfo['pidm']?:0} and standard_priority<>0 order by standard_priority
+ * select * from UP_USER where  user_name='${userInfo['user.login.id']?:''}'
+ * select '${@PortalDb.class.toString()}' as className from up_user where user_name='admin';
+ * </pre>
  * 
- * This portlet is useful for exposing dashboard components with relatively
- * low usage.  It does not presently implement caching and so is not suitable
- * for high volume use.
- * 
- * This portlet is eminently useful for simple administrative queries.
- * 
- * Potentially useful future enhancements of this portlet might include an
- * an ability to bind user attributes to parameters of the query.
- * 
- * This portlet is a modern port of the CSqlQuery channel to Spring PortletMVC.
- * 
+ * This portlet is useful for exposing results of a simple DB query as a single page for users.
+ *
  * @author Andrew Petro
  * @author Jen Bourey, jbourey@unicon.net
  * @revision $Revision$
  */
 public class SqlQueryPortletController extends AbstractController {
+    /**
+     * The name of the cache to use for sql results.  Defaults to DEFAULT_CACHE_NAME.  User should set to empty
+     * string to disable query results caching.  See portlet.xml.
+     */
+    public static final String PREF_CACHE_NAME = "cacheName";
+    public static final String DEFAULT_CACHE_NAME = "org.jasig.portal.portlets.sqlquery.SqlQueryPortletController.queryResults";
+
+    /**
+     * True (default) to have sql results cached per-user if caching is enabled.
+     */
+    public static final String PREF_CACHE_PER_USER = "perUserCache";
 
     /**
      * The bean name of the DataSource against which this channel will
@@ -71,8 +91,21 @@ public class SqlQueryPortletController extends AbstractController {
     public static final String SQL_QUERY_PARAM_NAME = "sql";
 
     public static final String VIEW_PARAM_NAME = "view";
-    
-	@Override
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    private IPortletSpELService portletSpELService;
+
+    @Autowired
+    public void setPortletSpELService(IPortletSpELService portletSpELService) {
+            this.portletSpELService = portletSpELService;
+        }
+
+    public String getPrefCacheName() {
+        return PREF_CACHE_NAME;
+    }
+
+    @Override
 	public ModelAndView handleRenderRequest(RenderRequest request,
 			RenderResponse response) throws Exception {
 		
@@ -81,22 +114,98 @@ public class SqlQueryPortletController extends AbstractController {
 		String sqlQuery = preferences.getValue(SQL_QUERY_PARAM_NAME, null);
 		String dsName = preferences.getValue(DATASOURCE_BEAN_NAME_PARAM_NAME, BasePortalJpaDao.PERSISTENCE_UNIT_NAME);
 		String viewName = preferences.getValue(VIEW_PARAM_NAME, "jsp/SqlQuery/results");
-		
-		// generate a JDBC template for the requested data source
-		DataSource ds = (DataSource) getApplicationContext().getBean(dsName);
-		JdbcTemplate template = new JdbcTemplate(ds);
-		
-		// Execute the SQL query and build a results object.  This result
-		// will consist of one rowname -> rowvalue map for each row in the
-		// result set
 
-		List<Map<String, Object>> results = template.query(sqlQuery, new ColumnMapRowMapper());
+        List<Map<String, Object>> results = null;
+        Cache cache = getCache(request);
+        String cacheKey = null;
+        if (cache != null) {
+            cacheKey = createCacheKey(request, sqlQuery);
+            Element cachedElement = cache.get(cacheKey);
+            if (cachedElement != null) {
+                log.debug("Cache hit. Returning item from cache {} for user {}, query {}", cache.getName(),
+                        request.getRemoteUser(), sqlQuery);
+                results = (List<Map<String, Object>>) cachedElement.getObjectValue();
+            }
+        }
+
+        if (results == null) {
+            // generate a JDBC template for the requested data source
+            DataSource ds = (DataSource) getApplicationContext().getBean(dsName);
+            JdbcTemplate template = new JdbcTemplate(ds);
+
+            // Allow substituting attributes from the request and userInfo objects using the SPEL ${} notation..
+            String spelSqlQuery = evaluateSpelExpression(sqlQuery, request);
+
+            // Execute the SQL query and build a results object.  This result will consist of one
+            // rowname -> rowvalue map for each row in the result set
+            results = template.query(spelSqlQuery, new ColumnMapRowMapper());
+            log.debug("found {} results for query {}", results.size(), spelSqlQuery);
+
+            if (cache != null) {
+                log.debug("Adding SQL results to cache {} for user {}, query {}", cache.getName(),
+                        request.getRemoteUser(), sqlQuery);
+                Element cachedElement = new Element(cacheKey, results);
+                cache.put(cachedElement);
+
+            }
+        }
 		
 		// build the model
-		
+
 		ModelAndView modelandview = new ModelAndView(viewName);
 		modelandview.addObject("results", results);
 		return modelandview;
 	}
 
+    /**
+     * Substitute any SpEL expressions with values from the PortletRequest and other attributes added to the
+     * SpEL context.
+     * @param value SQL Query String with optional SpEL expressions in it
+     * @param request Portlet request
+     * @return SQL Query string with SpEL substitutions
+     */
+    protected String evaluateSpelExpression(String value, PortletRequest request) {
+        if (StringUtils.isNotBlank(value)) {
+            String result = portletSpELService.parseString(value, request);
+            return result;
+        }
+        throw new IllegalArgumentException("SQL Query expression required");
+    }
+
+    /**
+     * Obtain the cache configured for this portlet instance.
+     * @param req Portlet request
+     * @return Cache configured for this portlet instance.
+     */
+    private Cache getCache(PortletRequest req) {
+        String cacheName = req.getPreferences().getValue(PREF_CACHE_NAME, DEFAULT_CACHE_NAME);
+        if (StringUtils.isNotBlank(cacheName)) {
+            log.debug("Looking up cache '{}'", cacheName);
+            Cache cache = CacheManager.getInstance().getCache(cacheName);
+            if (cache == null) {
+                throw new RuntimeException("Unable to find cache named " + cacheName + ". Check portlet preference value "
+                        + PREF_CACHE_NAME + " and configuration in ehcache.xml");
+            }
+            return cache;
+        } else {
+            log.debug("Portlet preference {} set to empty string; disabling caching for this portlet instance",
+                    PREF_CACHE_NAME);
+            return null;
+        }
+    }
+
+    /**
+     * Create a cache key that includes the bean name and if configured the logged in userId.  This allows multiple
+     * portlet instances to share the same cache (if desired but not recommended).
+     * @param req Portlet request
+     * @param rawSqlQuery SQL Query from portlet preferences (without SpEL substitution)
+     * @return Generated Cache key
+     */
+    private String createCacheKey(PortletRequest req, String rawSqlQuery) {
+        PortletPreferences prefs = req.getPreferences();
+        boolean perUser = Boolean.valueOf(prefs.getValue(PREF_CACHE_PER_USER, "true"));
+        String key = (perUser ? req.getRemoteUser() + "-": "") + rawSqlQuery + "-SqlQueryPortlet";
+        log.debug("Using cache key {}", key);
+        return key;
+    }
 }

--- a/uportal-war/src/main/resources/properties/contexts/portlet/SqlQuery-portlet.xml
+++ b/uportal-war/src/main/resources/properties/contexts/portlet/SqlQuery-portlet.xml
@@ -22,20 +22,20 @@
 
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="
-           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+           http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
+    <context:annotation-config/>
     <!-- Controllers -->
     
     <!-- main portlet view -->
     <bean id="sqlController"
         class="org.jasig.portal.portlets.sqlquery.SqlQueryPortletController"/>
-    
+
     <bean id="sqlConfigController"
         class="org.jasig.portal.portlets.sqlquery.SqlQueryConfigurationController">
-        <property name="formView" value="jsp/SqlQuery/config"/>
-        <property name="commandClass" value="org.jasig.portal.portlets.sqlquery.SqlQueryConfigForm"/>
-        <property name="commandName" value="form"/>
     </bean>
     
     <!-- Handler Mapping -->

--- a/uportal-war/src/main/resources/properties/ehcache.xml
+++ b/uportal-war/src/main/resources/properties/ehcache.xml
@@ -438,7 +438,16 @@
         eternal="false" maxElementsInMemory="5000" overflowToDisk="false" diskPersistent="false" 
         timeToIdleSeconds="900" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true" />
 
-    <!-- 
+    <!--
+     | Caches compiled portlet SpEL Expression objects
+     | - 1 x expression used in the portal
+     | - not replicated
+     +-->
+    <cache name="portletSpELExpressionCache"
+           eternal="false" maxElementsInMemory="100" overflowToDisk="false" diskPersistent="false"
+           timeToIdleSeconds="900" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true" />
+
+    <!--
      | Caches post-layout pipeline events
      | - 1 x user x navigational state
      | - not replicated
@@ -1779,5 +1788,20 @@
     <cache name="org.jasig.portal.groups.pags.dao.jpa.PersonAttributesGroupDefinitionImpl.Query"
            eternal="false" overflowToDisk="false" diskPersistent="false"
            maxElementsInMemory="100" timeToIdleSeconds="0" timeToLiveSeconds="0" memoryStoreEvictionPolicy="LRU" statistics="true"/>
-    
+
+    <!-- ****************************************************************** -->
+    <!-- ******************** uPortal Portlet Caches ******************** -->
+    <!-- ****************************************************************** -->
+
+    <!--
+     | Default cache for query results from SqlQueryPortletController. May be per-user (configurable with portlet
+     | preferences).  If using multiple SqlQueryPortlet instances, though not required, you typically would create
+     | a separate cache for each instance to reduce filling the cache and to adjust timeToLive.
+     | - 1 x expression used in the portal
+     | - not replicated
+     +-->
+    <cache name="org.jasig.portal.portlets.sqlquery.SqlQueryPortletController.queryResults"
+           eternal="false" maxElementsInMemory="2000" overflowToDisk="false" diskPersistent="false"
+           timeToIdleSeconds="0" timeToLiveSeconds="300" memoryStoreEvictionPolicy="LRU" statistics="true" />
+
 </ehcache>

--- a/uportal-war/src/main/webapp/WEB-INF/jsp/SqlQuery/config.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/SqlQuery/config.jsp
@@ -21,7 +21,11 @@
 
 <%@ include file="/WEB-INF/jsp/include.jsp"%>
 <c:set var="n"><portlet:namespace/></c:set>
-<portlet:actionURL var="queryUrl" escapeXml="false"/>
+<%-- escapeXml=false is required to allow config mode to work within the Spring Webflow of Manage Portlets. Otherwise
+     the executionKey is lost because &pP_execution=e2s3 becomes &amp;amp;pP_execution=e2s3 --%>
+<portlet:actionURL var="formUrl" escapeXml="false">
+    <portlet:param name="action" value="updateConfiguration"/>
+</portlet:actionURL>
 
 <!-- Portlet -->
 <div class="fl-widget portlet" role="section">
@@ -34,7 +38,7 @@
   <!-- Portlet Body -->
   <div class="fl-widget-content portlet-body" role="main">
 
-    <form:form modelAttribute="form" action="${queryUrl}" method="POST">
+    <form:form class="form-horizontal" role="form" modelAttribute="form" action="${formUrl}" method="POST">
     
     <!-- Portlet Messages -->
     <spring:hasBindErrors name="form">
@@ -49,9 +53,15 @@
     
         <p>
     	    <label class="portlet-form-field-label">SQL query:</label>
-	       <form:input path="sqlQuery" size="120"/>
+	       <form:textarea path="sqlQuery" rows="4" cols="120"/>
+            <div>Allows Spring Expression Language (SpEL) expressions such as \${request.contextPath}, \${userInfo['user.login.id']}, or @MyBeanName<br/>
+              You typically define a default using the elvis operator ?: in case an attribute has no value to avoid sql grammar errors; e.g. something like<br/>
+              select * from EB_CONTACT_TABLE where pidm = \${userInfo['pidm']?:0} and standard_priority<>0 order by standard_priority<br>
+              select * from UP_USER where  user_name='\${userInfo['user.login.id']?:''}'<br/>
+              select '\${@PortalDb.class.toString()?:unknown}' as className from up_user where user_name='admin';
+            </div>
 	    </p>
-	
+
 	    <p>
     	    <label class="portlet-form-field-label">Spring data source bean name:</label>
 	       <form:input path="dataSource" size="50"/>
@@ -61,13 +71,29 @@
 	       <label class="portlet-form-field-label">Spring view:</label>
 	       <form:input path="viewName" size="50"/>
 	    </p>
+
+        <p>
+            <label class="portlet-form-field-label">Cache name:</label>
+            <form:input path="cacheName" size="50"/>
+            <div>Enter 'org.jasig.portal.portlets.sqlquery.SqlQueryPortletController.queryResults' for preconfigured cache. If other than the preconfigured cache name, you must create a cache in ehcache.xml with the name you enter here.<br/>
+                 Leave empty to disable caching (note: recommended only for administrative portlets that have very low usage).
+             </div>
+
+        </p>
+
+        <p>
+            <label class="portlet-form-field-label">Per-user caching:</label>
+            <form:checkbox path="perUserCaching"/>
+            <span>Only applicable if using caching</span>
+        </p>
     
       </div>
     </div> <!-- end: portlet-section -->
     
     <!-- Portlet Buttons -->
     <div class="portlet-button-group">
-      <input class="portlet-button portlet-button-primary" type="submit" value="Save"/>
+      <input class="portlet-button portlet-button-primary" type="submit" name="Save" value="Save"/>
+      <input class="portlet-button" type="submit" name="Cancel" value="Cancel"/>
     </div>
     
     </form:form> <!-- End Form -->

--- a/uportal-war/src/main/webapp/WEB-INF/portlet.xml
+++ b/uportal-war/src/main/webapp/WEB-INF/portlet.xml
@@ -324,6 +324,31 @@
         <portlet-info>
             <title>Sql Query</title>
         </portlet-info>
+        <portlet-preferences>
+            <!--
+             | The name of the cache in ehcache.xml to cache the sql results set.  A preconfigured cache named
+             | org.jasig.portal.portlets.sqlquery.SqlQueryPortletController.queryResults exists in ehcache.xml,
+             | but you can define other cache names in ehcache.xml with whatever retention characteristics are
+             | needed and configure different SqlQuery Portlet instances to use the different caches.
+             |
+             | The cache key includes the query string so multiple SqlQuery Portlet instances could share the
+             | same cache if desired.
+             |
+             | To disable caching, use an empty cache name.
+             +-->
+            <preference>
+                <name>cacheName</name>
+                <value></value>
+            </preference>
+            <!--
+             | If using caching, determines whether the portlet's cache is global or per-user (default); e.g. whether
+             | the cache key contains the user's login ID.  Only disable if the results are the same for EVERY user.
+             +-->
+            <preference>
+                <name>perUserCache</name>
+                <value>true</value>
+            </preference>
+        </portlet-preferences>
     </portlet>
     
     <portlet>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4131

Enhancements to framework portlet SqlQuery include:
- configurable cache of results (with default available cache to use)
- per-user caching
- SpEL expressions using request, userInfo, and `@bean` in SQL Query
