### PR TITLE
Fixes bug in presenting marketplace screenshots

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/portlet/entry.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/portlet/entry.jsp
@@ -168,47 +168,62 @@
         <%-- Start with Screen shots and what not --%>
         <%--TODO replace carousel with more accessibility friendly element --%>
         <c:if test="${not empty portlet.screenShots}">
-            <div class="row">
-                <div class="col-xs-12 col-md-4">
-                    <p>
-                        <span class="marketplace_section_header"><spring:message code="screenshots.cap" text="SCREENSHOTS/VIDEOS"/></span>
-                    </p>
-                    <div id="marketplace_screenshots_and_videos" class="carousel slide" data-ride="carousel" data-interval="9000" data-wrap="true">
-                        <c:set var="validUrlCount" value="0"/>
-                        <div class="carousel-inner marketplace_carousel_inner">
-                        <c:forEach var="screenShot" items="${portlet.screenShots}">
-                            <c:set var="imageUrl" value="${screenShot.url}" />
-                            <c:if test="${up:isValidUrl(imageUrl)}">
-                                    <div class="item marketplace_screen_shots">
-                                       <img src="${imageUrl}" alt="screenshot for portlet">
-                                        <c:if test="${not empty screenShot.captions}">
-                                            <div class="carousel-caption">
-                                                <c:forEach var="portletCaption" items="${screenShot.captions}">
-                                                    <h3>${portletCaption}</h3>
-                                                </c:forEach>
-                                            </div>
-                                        </c:if>
-                                        <c:set var="validUrlCount" value="${validUrlCount + 1}" />
-                                    </div>
-                            </c:if>
-                        </c:forEach>
-                        </div>
-                        <ol class="carousel-indicators marketplace_carousel_indicators">
-                            <c:forEach var="i" begin="0" end="${validUrlCount-1}">
-                                <li data-target="#marketplace_screenshots_and_videos" data-slide-to="${i}"></li>
-                            </c:forEach>
-                        </ol>
-                        <c:if test="${validUrlCount gt 1}">
-                            <a class="left carousel-control" href="#marketplace_screenshots_and_videos" data-slide="prev">
-                                <span class="glyphicon glyphicon-chevron-left"></span>
-                            </a>
-                            <a class="right carousel-control" href="#marketplace_screenshots_and_videos" data-slide="next">
-                                <span class="glyphicon glyphicon-chevron-right"></span>
-                            </a>
+            <c:set var="validUrlCount" value="0"/>
+            <c:forEach var="screenShot" items="${portlet.screenShots}">
+                <c:set var="imageUrl" value="${screenShot.url}" />
+                <c:if test="${up:isValidUrl(imageUrl)}">
+                    <c:set var="validUrlCount" value="${validUrlCount + 1}" />
+                    <%--If validUrlCount is 1 then we can make a header--%>
+                    <c:if test="${validUrlCount==1}">
+                        <div class="row">
+                            <div class="col-xs-12 col-md-4">
+                                <p>
+                                    <span class="marketplace_section_header">
+                                        <spring:message code="screenshots.cap" text="SCREENSHOTS/VIDEOS"/>
+                                    </span>
+                                </p>
+                                <div id="marketplace_screenshots_and_videos" class="carousel slide" data-ride="carousel" data-interval="9000" data-wrap="true">
+                                    <%--Adds a carousel inner div --%>
+                                    <div class="carousel-inner marketplace_carousel_inner">
+                    </c:if>
+                    <div class="item marketplace_screen_shots">
+                       <img src="${imageUrl}" alt="screenshot for portlet">
+                        <c:if test="${not empty screenShot.captions}">
+                            <div class="carousel-caption">
+                                <c:forEach var="portletCaption" items="${screenShot.captions}">
+                                    <h3>${portletCaption}</h3>
+                                </c:forEach>
+                            </div>
                         </c:if>
                     </div>
+                </c:if>
+            </c:forEach>
+            <%--Closes the carousel-inner marketplace_carousel_inner div --%>
+            <c:if test="${validUrlCount gt 0}">
                 </div>
-            </div>
+            </c:if>
+            <%--Only add the little prev/next arrows when screenshots>1 --%>
+            <c:if test="${validUrlCount gt 1}">
+                <ol class="carousel-indicators marketplace_carousel_indicators">
+                    <c:forEach var="i" begin="0" end="${validUrlCount-1}">
+                        <li data-target="#marketplace_screenshots_and_videos" data-slide-to="${i}"></li>
+                    </c:forEach>
+                </ol>
+                <a class="left carousel-control" href="#marketplace_screenshots_and_videos" data-slide="prev">
+                    <span class="glyphicon glyphicon-chevron-left"></span>
+                </a>
+                <a class="right carousel-control" href="#marketplace_screenshots_and_videos" data-slide="next">
+                    <span class="glyphicon glyphicon-chevron-right"></span>
+                </a>
+            </c:if>
+            <c:if test="${validUrlCount gt 0}">
+                <%--Closes the marketplace_screenshots_and_videos div--%>
+                </div>
+                <%--Closes the col div --%>
+                </div>
+                <%--Closes the row div --%>
+                </div>
+            </c:if>
         </c:if>
         <br>
         <div class="row col-xs-12" style="clear:both;">


### PR DESCRIPTION
 Bug occurs if portlet provides screenshots (any number) and all the screen shot urls provided do not return the anticipated 200 response code.  This would lead to this error:
![image](https://cloud.githubusercontent.com/assets/5521429/3246466/badab706-f17b-11e3-8b50-4dd28986cf47.png)

It would happen because the code did not deal with this edge case well.  The provided list was not empty, but the valid list was empty.  This led to some initial setup that actually couldn't be done.  This PR uses the validUrlCount variable already created.  It now deals with that edge case and only shows the header if there is at least one valid url.
## Step by Step with pictures!
### A portlet provides two screen shots that work great:

![image](https://cloud.githubusercontent.com/assets/5521429/3246090/3a306f7c-f178-11e3-8ba0-c9b1945a163a.png)
### Let's go mess up the screenshot url to a non existant url.  (This could also mean that the hosting service is down or a url is incorrect):
#### Before:

![image](https://cloud.githubusercontent.com/assets/5521429/3246118/88450ac4-f178-11e3-8dae-5130963a982a.png)
#### After (notice screenshot 1 url):

![image](https://cloud.githubusercontent.com/assets/5521429/3246367/e24044c4-f17a-11e3-896b-196eee37ba43.png)
### Now, the screenshot doesn't show, the prev/next arrows go away and everything looks good:

![image](https://cloud.githubusercontent.com/assets/5521429/3246386/17d349e2-f17b-11e3-990d-161e4105e27e.png)
### Now, with both screenshot urls returning not-200 response codes:

![image](https://cloud.githubusercontent.com/assets/5521429/3246454/99750c24-f17b-11e3-8bb2-e8c366e95d8f.png)
### What it looked like previously:

![image](https://cloud.githubusercontent.com/assets/5521429/3246466/badab706-f17b-11e3-8b50-4dd28986cf47.png)
#### So now, we don't have an exception and the screenshot heading goes away!
### Issues that weren't addressed:
- Caching of said URL's
- Definition of URL validity
- Implementation of determining URL validity
