### PR TITLE
UP-3950 : Remove portlet bugfix 

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -397,7 +397,7 @@
       </xsl:if>
 
       <!-- Remove Icon -->
-      <xsl:if test="not(@dlm:deleteAllowed='false') and not(//focused) and /layout/navigation/tab[@activeTab='true']/@immutable='false'">
+      <xsl:if test="@unremovable='false' and not(//focused) and /layout/navigation/tab[@activeTab='true']/@immutable='false'">
         <!-- calls a layout api on click that removes the current node from the layout -->
         <li>
           <a id="removePortlet_{@ID}" title="{upMsg:getMessage('are.you.sure.remove.portlet', $USER_LANG)}" href="#" class="up-portlet-control remove"><xsl:value-of select="upMsg:getMessage('remove', $USER_LANG)"/></a>


### PR DESCRIPTION
In JIRA: [UP-3950](https://issues.jasig.org/browse/UP-3950).

Remove happens via an ajax call on the onclick event in the layout preferences JS file.  However, we still have the anchor tag that never gets called, unless there is a JS error on the page preventing the handler from being created.

This removes that unneeded anchor tag.

This also fixes a permission issue to check whether the Remove option should be visible.  
