### PR TITLE
Sets an image height for mktplace screenshots

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/portlet/entry.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/portlet/entry.jsp
@@ -130,6 +130,15 @@
     
     #${n} .marketplace_carousel_inner img {
         max-height : 20em;
+        position:absolute;
+        top:0;
+        bottom:0;
+        right:0;
+        left:0;
+    }
+    
+    #${n} .marketplace_carousel_inner .item{
+        height: 20em;
     }
 
     #${n} #${n}marketplace_user_review_input, #${n}marketplace_user_rating_submit_button{


### PR DESCRIPTION
Prevents the marketplace entry page from bouncing up
and down when a portlet has screenshots with
different heights.

The max height of an image was already set to 20em.  This pull request makes the container 20em as well and centers any image that does not fit.

Before the image container would be the same height as the image (even when the image was less than 20em), producing a 'boucing image affect' (https://coderwall.com/p/uf2pka) for images with different height. 

Now:

![image](https://cloud.githubusercontent.com/assets/5521429/3292914/ec695738-f594-11e3-8578-794f9f324b2a.png)

![image](https://cloud.githubusercontent.com/assets/5521429/3292918/f3a14204-f594-11e3-82a8-95585a6b7ad8.png)
