### PR TITLE
UP-4144 add travis-ci configuration on 4.0-patches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+before_install:
+  - unset GEM_PATH


### PR DESCRIPTION
uPortal `master` has been successfully using Travis-CI for build-and-tests sanity checking for `master` HEAD and for the putative results of merging pull requests against `master` for a while now.

This commit applies the necessary Travis configuration to `rel-4.0-patches` so that Travis will do this same sanity checking for 4.0 patches and for branches of and proposed pull requests against it.  This will fulfill [UP-4144](https://issues.jasig.org/browse/UP-4144) so that issues is resolved for both `4.1.0` and for `4.0.15`.

Example: [the successful Travis build and test](https://travis-ci.org/apetro/uPortal/builds/27715092) of the branch behind this pull request.
