### PR TITLE
UP-4122: Customization drawer does not display (IE).

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -270,7 +270,7 @@
             return false;
           });
           // Console for debugging.
-          console.debug("menu", menu, "menuToggle", menuToggle);
+          console.log("menu", menu, "menuToggle", menuToggle);
         }
 
         navMenuToggle();

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-favorite.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-favorite.js
@@ -75,7 +75,7 @@ var up = up || {};
             dataType: "json",
             async: true,
             success: function (){
-              console.debug("layout move successful. URL: " + theURL);
+              console.log("layout move successful. URL: " + theURL);
             },
             error: function(request, text, error) {
               $('#up-notification').noty({text: request.response, type: 'error'});


### PR DESCRIPTION
- IE 10 was choking on the console.debug statements.
- These statements were replaced with console.log().
- This fix resolves several other tickets: UP-4121, UP-4122, UP-4123
