### PR TITLE
UP-4143 EventSession purge fails to page, OutOfMemory can result

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/events/aggr/session/JpaEventSessionDao.java
+++ b/uportal-war/src/main/java/org/jasig/portal/events/aggr/session/JpaEventSessionDao.java
@@ -44,6 +44,7 @@ import org.jasig.portal.security.IPerson;
 import org.jasig.portal.utils.cache.CacheKey;
 import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 import com.google.common.base.Function;
@@ -55,16 +56,24 @@ import com.google.common.base.Function;
 @Repository("eventSessionDao")
 public class JpaEventSessionDao extends BaseAggrEventsJpaDao implements EventSessionDao {
     private final static String EVENT_SESSION_CACHE_SOURCE = JpaEventSessionDao.class.getName() + "_EVENT_SESSION";
+    private int maxPurgeBatchSize;
 
     private String deleteByEventSessionIdQuery;
     private CriteriaQuery<EventSessionImpl> findExpiredEventSessionsQuery;
+    private CriteriaQuery<Long> countExpiredEventSessionsQuery;
     private ParameterExpression<String> eventSessionIdParameter;
     private ParameterExpression<DateTime> dateTimeParameter;
     
     private AggregatedGroupLookupDao aggregatedGroupLookupDao;
     private ICompositeGroupService compositeGroupService;
     private EntityManagerCache entityManagerCache;
-    
+
+    @Autowired
+    @Value("${org.jasig.portal.events.aggr.session.JpaEventSessionDao.maxPurgeBatchSize:100000}")
+    public void setMaxPurgeBatchSize(int maxPurgeBatchSize) {
+        this.maxPurgeBatchSize = maxPurgeBatchSize;
+    }
+
     @Autowired
     public void setEntityManagerCache(EntityManagerCache entityManagerCache) {
         this.entityManagerCache = entityManagerCache;
@@ -95,6 +104,20 @@ public class JpaEventSessionDao extends BaseAggrEventsJpaDao implements EventSes
                         cb.lessThanOrEqualTo(root.get(EventSessionImpl_.lastAccessed), dateTimeParameter)
                     );
                 
+                return criteriaQuery;
+            }
+        });
+
+        this.countExpiredEventSessionsQuery = this.createCriteriaQuery(new Function<CriteriaBuilder, CriteriaQuery<Long>>() {
+            @Override
+            public CriteriaQuery<Long> apply(CriteriaBuilder cb) {
+                final CriteriaQuery<Long> criteriaQuery = cb.createQuery(Long.class);
+                final Root<EventSessionImpl> root = criteriaQuery.from(EventSessionImpl.class);
+                criteriaQuery.select(cb.count(root));
+                criteriaQuery.where(
+                        cb.lessThanOrEqualTo(root.get(EventSessionImpl_.lastAccessed), dateTimeParameter)
+                );
+
                 return criteriaQuery;
             }
         });
@@ -149,16 +172,30 @@ public class JpaEventSessionDao extends BaseAggrEventsJpaDao implements EventSes
     }
 
     @AggrEventsTransactional
-    @Override
-    public int purgeEventSessionsBefore(DateTime lastAggregatedEventDate) {
+    private void purgeEventList(int begin, int end, DateTime lastAggregatedEventDate) {
         final TypedQuery<EventSessionImpl> query = this.createQuery(this.findExpiredEventSessionsQuery);
         query.setParameter(this.dateTimeParameter, lastAggregatedEventDate);
+        query.setFirstResult(begin);
+        query.setMaxResults(end);
         final List<EventSessionImpl> resultList = query.getResultList();
         for (final EventSessionImpl eventSession : resultList) {
             this.getEntityManager().remove(eventSession);
         }
+    }
+
+    @AggrEventsTransactional
+    @Override
+    public int purgeEventSessionsBefore(DateTime lastAggregatedEventDate) {
+        final TypedQuery<Long> countQuery = this.createQuery(this.countExpiredEventSessionsQuery);
+        countQuery.setParameter(this.dateTimeParameter, lastAggregatedEventDate);
+        final int totalRows =   countQuery.getSingleResult().intValue();
+
+        final int numberBatches = totalRows / maxPurgeBatchSize;
+        for(int i = 0; i <= numberBatches; i++) {
+            purgeEventList((i * maxPurgeBatchSize),(((i+1)* maxPurgeBatchSize) - 1),lastAggregatedEventDate );
+        }
         
-        return resultList.size();
+        return totalRows;
     }
     
     /**

--- a/uportal-war/src/main/resources/properties/portal.properties
+++ b/uportal-war/src/main/resources/properties/portal.properties
@@ -192,6 +192,13 @@ org.jasig.portal.email.fromAddress=${environment.build.uportal.email.fromAddress
 #org.jasig.portal.events.handlers.db.JpaPortalEventStore.aggregationFlushPeriod=1000
 
 ##
+## Number batch event sessions to purge event sessions at given time. The purge will delete expired
+#  event sessions.  This property prevents your server from running out of memory or excessive
+#  swapping if a large number of event sessions need to be purged.  Default is 100000.
+##
+#org.jasig.portal.events.aggr.session.JpaEventSessionDao.maxPurgeBatchSize=100000
+
+##
 ## Duration subtracted from "now" when looking for new events to aggregate. The delay ensures
 ## that all events for the aggregation timespan have been written to the database from all
 ## servers in the cluster

--- a/uportal-war/src/test/java/org/jasig/portal/events/aggr/session/JpaEventSessionDaoTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/events/aggr/session/JpaEventSessionDaoTest.java
@@ -19,17 +19,7 @@
 
 package org.jasig.portal.events.aggr.session;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
-import javax.naming.CompositeName;
-
+import com.google.common.collect.ImmutableSet;
 import org.jasig.portal.concurrency.CallableWithoutResult;
 import org.jasig.portal.events.LoginEvent;
 import org.jasig.portal.events.TestEventFactory;
@@ -38,13 +28,20 @@ import org.jasig.portal.groups.ICompositeGroupService;
 import org.jasig.portal.groups.IEntityGroup;
 import org.jasig.portal.security.IPerson;
 import org.jasig.portal.test.BaseAggrEventsJpaDaoTest;
+import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.google.common.collect.ImmutableSet;
+import javax.naming.CompositeName;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Eric Dalquist
@@ -65,62 +62,38 @@ public class JpaEventSessionDaoTest extends BaseAggrEventsJpaDaoTest {
         when(everyoneGroup.getServiceName()).thenReturn(new CompositeName("local"));
         when(everyoneGroup.getName()).thenReturn("Everyone");
         when(compositeGroupService.findGroup("local.0")).thenReturn(everyoneGroup);
-        
+
         final IEntityGroup adminGroup = mock(IEntityGroup.class);
         when(adminGroup.getServiceName()).thenReturn(new CompositeName("local"));
         when(adminGroup.getName()).thenReturn("Admins");
         when(compositeGroupService.findGroup("local.1")).thenReturn(adminGroup);
-        
+
         final IPerson person = mock(IPerson.class);
+//
+//        Example event session "1234567890_abcdefg";
+        final int EVENT_SESSION_LENGTH = 17;
+        final int EVENT_SESSION_HYPHEN_LENGTH = 10;
 
-        final String eventSessionId1 = "1234567890_abcdefg";
-        final String eventSessionId2 = "0000000000_aaaaaaa";
-        
-        final LoginEvent loginEvent1 = TestEventFactory.newLoginEvent(this, "testServer", eventSessionId1, person, 
-                ImmutableSet.<String>of("local.0", "local.1"), 
-                Collections.<String, List<String>>emptyMap());
-        
-        final LoginEvent loginEvent2 = TestEventFactory.newLoginEvent(this, "testServer", eventSessionId2, person, 
-                ImmutableSet.<String>of("local.0", "local.1"), 
-                Collections.<String, List<String>>emptyMap());
-        
+        this.execute(new CallableWithoutResult() {
+            @Override
+            protected void callWithoutResult() {
+                DateTime timeStamp = null;
+                for (int i = 0; i <= 100; i++) {
+                    String sessionId = UUID.randomUUID().toString().replaceAll("[\\s\\-()]", "").substring(0, EVENT_SESSION_LENGTH - 1);
+                    sessionId = sessionId.substring(0, 10) + "_" + sessionId.substring(EVENT_SESSION_HYPHEN_LENGTH, sessionId.length());
+                    LoginEvent loginEvent = TestEventFactory.newLoginEvent(this, "testServer", sessionId, person,
+                            ImmutableSet.<String>of("local.0", "local.1"),
+                            Collections.<String, List<String>>emptyMap());
+                    final EventSession eventSession = eventSessionDao.getEventSession(loginEvent);
+                    assertNotNull(eventSession);
+                    assertEquals(sessionId, eventSession.getEventSessionId());
+                    final Set<AggregatedGroupMapping> groupMappings = eventSession.getGroupMappings();
+                    assertEquals(2, groupMappings.size());
+                    timeStamp = loginEvent.getTimestampAsDate();
+                }
+                eventSessionDao.purgeEventSessionsBefore(timeStamp.plusYears(1));
+            }
+        });
 
-        
-        this.execute(new CallableWithoutResult() {
-            @Override
-            protected void callWithoutResult() {
-                final EventSession eventSession1 = eventSessionDao.getEventSession(loginEvent1);
-                assertNotNull(eventSession1);
-                assertEquals(eventSessionId1, eventSession1.getEventSessionId());
-                final Set<AggregatedGroupMapping> groupMappings1 = eventSession1.getGroupMappings();
-                assertEquals(2, groupMappings1.size());
-                
-                final EventSession eventSession2 = eventSessionDao.getEventSession(loginEvent2);
-                assertNotNull(eventSession2);
-                assertEquals(eventSessionId2, eventSession2.getEventSessionId());
-                final Set<AggregatedGroupMapping> groupMappings2 = eventSession2.getGroupMappings();
-                assertEquals(2, groupMappings2.size());
-            }
-        });
-        
-        this.execute(new CallableWithoutResult() {
-            @Override
-            protected void callWithoutResult() {
-                final EventSession eventSession = eventSessionDao.getEventSession(loginEvent1);
-                assertNotNull(eventSession);
-                
-                assertEquals(eventSessionId1, eventSession.getEventSessionId());
-                
-                final Set<AggregatedGroupMapping> groupMappings = eventSession.getGroupMappings();
-                assertEquals(2, groupMappings.size());
-            }
-        });
-        
-        this.execute(new CallableWithoutResult() {
-            @Override
-            protected void callWithoutResult() {
-                eventSessionDao.purgeEventSessionsBefore(loginEvent1.getTimestampAsDate().plusYears(1));
-            }
-        });
     }
 }

--- a/uportal-war/src/test/resources/jpaAggrEventsTestContext.xml
+++ b/uportal-war/src/test/resources/jpaAggrEventsTestContext.xml
@@ -71,6 +71,7 @@
         <property name="properties">
             <props>
                 <prop key="persistenceUnitName">AggrEventsDb</prop>
+                <prop key="org.jasig.portal.events.aggr.session.JpaEventSessionDao.maxPurgeBatchSize">10</prop>
             </props>
         </property>
     </bean>


### PR DESCRIPTION
From ticket ...
As a uPortal adopter, I would like my portal to not run out of memory when it tries to purge a large number of EventSessions.  JpaEventSessionDao in purgeEventSessionsBefore() attempts to load all the matching sessions and then step through the list deleting them one by one, rather than loading them in smaller batches. This can result in an out of memory.

See uportal-dev@ thread re: http://thread.gmane.org/gmane.comp.java.jasig.uportal.devel/5743 .
