### PR TITLE
UP-4063 Add trivial unit test.

### DIFF
--- a/uportal-war/src/test/java/org/jasig/portal/portlets/portletadmin/PortletAdministrationHelperTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/portlets/portletadmin/PortletAdministrationHelperTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.portlets.portletadmin;
+
+import org.jasig.portal.portlet.dao.jpa.PortletTypeImpl;
+import org.jasig.portal.portlet.om.IPortletType;
+import org.jasig.portal.portletpublishing.xml.PortletPublishingDefinition;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertNull;
+
+/**
+ * Unit test for PortletAdministrationHelper.
+ */
+public class PortletAdministrationHelperTest {
+
+    /**
+     * When there are multiple available portlet types, the method
+     * updateFormForSinglePortletType(...)
+     * is a no-op returning null.
+     *
+     * This test case verifies that the method returns null in this case.
+     */
+    @Test
+    public void updateFormForSinglePortletTypeNoOpWhenMultiplePortletTypes() {
+
+        PortletAdministrationHelper helper = new PortletAdministrationHelper();
+
+        Map<IPortletType, PortletPublishingDefinition> portletDefinitions = new HashMap<>();
+
+        IPortletType someType = new PortletTypeImpl("someType", "someUri");
+        IPortletType someOtherType = new PortletTypeImpl("someOtherType", "someOtherUri");
+
+        PortletPublishingDefinition someDefinition = new PortletPublishingDefinition();
+        PortletPublishingDefinition someOtherDefinition = new PortletPublishingDefinition();
+
+        portletDefinitions.put(someType, someDefinition);
+        portletDefinitions.put(someOtherType, someOtherDefinition);
+
+        PortletDefinitionForm form = new PortletDefinitionForm();
+
+        assertNull( helper.updateFormForSinglePortletType(portletDefinitions, form) );
+
+    }
+}


### PR DESCRIPTION
This is a trivial JUnit test.  Someone should just hit the green Merge button so that uPortal includes just a smidgeon more unit test coverage.

---

The origin of this unit test is that I'd written to demonstrate [Coveralls' lovely reporting](https://github.com/apetro/uPortal/pull/1#issuecomment-46627642) on how a pull request will change the test coverage metrics.  Having written this start at unit testing for `PortletAdministrationHelper`, seems worth slurping this into the uPortal codebase and improving test coverage ever so slightly (hey, 0.08% here, 0.08% there, sooner or later you're at 25% test coverage.)

Tests functionality introduced in [UP-4063](https://issues.jasig.org/browse/UP-4063) that `PortletAdminstrationHelper.updateFormForSinglePortletType()` returns `null` when multiple types available.

Obviously, much more than this trivial test could be undertaken to automate testing `PortletAdministrationHelper` against regression, and that'd be nice scaffolding to have in place to support a refactor of that code.
