### PR TITLE
Name of favorite will go to favorite during edit

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Favorites/edit.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Favorites/edit.jsp
@@ -68,7 +68,10 @@
           <c:choose>
             <c:when test="${collection.deleteAllowed}">
               <a href="${unFavoriteCollectionUrl}">
-                <span class="glyphicon glyphicon-trash pull-right"></span>${collection.name}
+                <span class="glyphicon glyphicon-trash pull-right"></span>
+              </a>
+              <a href="${renderRequest.contextPath}/f/${collection.id}/render.uP">
+                ${collection.name}
               </a>
             </c:when>
             <c:otherwise>
@@ -99,7 +102,10 @@
           <c:choose>
             <c:when test="${favorite.deleteAllowed}">
               <a href="${unFavoritePortletUrl}">
-                <span class="glyphicon glyphicon-trash pull-right"></span>${favorite.name}
+                <span class="glyphicon glyphicon-trash pull-right"></span>
+              </a>
+              <a href="${renderRequest.contextPath}/p/${favorite.functionalName}/render.uP">
+                ${favorite.name}
               </a>
             </c:when>
             <c:otherwise>


### PR DESCRIPTION
In edit mode, the name of the favorite would delete the favorite.  Now, this uses the **exact same URL** from the view mode to send you to the favorite.

Notice the URL pop up in bottom left of screen.
# Before:

![image](https://cloud.githubusercontent.com/assets/5521429/3375356/def1c38a-fbc8-11e3-923c-0fc8f8b1a474.png)
# After:

![image](https://cloud.githubusercontent.com/assets/5521429/3375335/b007326c-fbc8-11e3-9485-f07c21a60047.png)
