### PR TITLE
No squishy parts

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/portlet/view.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/portlet/view.jsp
@@ -58,7 +58,7 @@
     float: right;
 }
 
-#${n}marketplace  .dataTables_info, .dataTables_length, .dataTables_paginate{
+#${n}marketplace .dataTables_paginate{
     white-space:nowrap;
 }
 
@@ -382,8 +382,8 @@
                        applyEllipsis(nRow,1,75);
                       },
                 "sDom": '<"top"f><"sort_info"><"${n}sort_buttons"><rt'+
-                    '<"row ${n}bottom" <"col-xs-6 col-md-3" i>'+
-                    '<"col-xs-6 col-md-push-6 col-md-3"l>'+
+                    '<"row ${n}bottom" <"col-xs-6 col-sm-8 col-md-3" i>'+
+                    '<"col-xs-6 col-md-push-6 col-sm-4 col-md-3"l>'+
                     '<"col-xs-12 col-md-pull-3 col-md-6"p>>',
                 "bStateSave": true,
                 "bAutoWidth":false


### PR DESCRIPTION
When scaling down to smaller screens, parts of the screen would get `squishy`.  The buttons and the text info at the bottom.  Those parts now take up a bit more screen real estate.  Note, the buttons didn't look too bad before, but on tiny screens, it would look really bad.

Before:
![image](https://cloud.githubusercontent.com/assets/5521429/3377448/5c7c00b6-fbdf-11e3-99d3-29715c3d8c7c.png)

After:
![image](https://cloud.githubusercontent.com/assets/5521429/3377452/65f615dc-fbdf-11e3-8782-3298e3fc4a9a.png)

More screenshots requested. 

Small:
![image](https://cloud.githubusercontent.com/assets/5521429/3390216/8c25a264-fc9c-11e3-9353-64ac7dc131a8.png)

Medium:
![image](https://cloud.githubusercontent.com/assets/5521429/3390207/81c2bcd0-fc9c-11e3-9fd1-14d187d49619.png)

 I had the UW portal open, so that's the skin they're from.

Small:
![image](https://cloud.githubusercontent.com/assets/5521429/3377862/dcdedf72-fbe3-11e3-916e-9a3c8177d1c9.png)

Medium:
![image](https://cloud.githubusercontent.com/assets/5521429/3377877/ea496f88-fbe3-11e3-92dc-b326c2682309.png)
