### PR TITLE
UP-4156 Upgrade to released fluid 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
         <pluto.version>2.1.0-M3</pluto.version>
         <portlet-api.version>2.0</portlet-api.version>
         <quartz.version>2.2.1</quartz.version>
-        <resource-server.version>1.0.38</resource-server.version>
+        <resource-server.version>1.0.41</resource-server.version>
         <servlet-api.version>3.0.1</servlet-api.version>
         <slf4j.version>1.7.7</slf4j.version>
         <spring-framework.version>3.1.4.RELEASE</spring-framework.version>

--- a/uportal-war/src/main/webapp/media/skins/muniversality/common/common_skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/muniversality/common/common_skin.xml
@@ -64,8 +64,8 @@
     <js included="aggregated" resource="true">/rs/jquery-plugins/validation/1.11.1/jquery.validate-1.11.1.min.js</js>
     <js included="aggregated" resource="true">/rs/jquery-plugins/validation/1.11.1/additional-methods-1.11.1.min.js</js>
 
-    <js included="plain" resource="true">/rs/fluid/pre1.5.0-6cb52a5083/js/fluid-custom.js</js>
-    <js included="aggregated" resource="true">/rs/fluid/pre1.5.0-6cb52a5083/js/fluid-custom.min.js</js>
+    <js included="plain" resource="true">/rs/fluid/1.5.0/js/fluid-custom.js</js>
+    <js included="aggregated" resource="true">/rs/fluid/1.5.0/js/fluid-custom.min.js</js>
 
     <js included="plain" resource="true">/rs/underscore/1.5.2/underscore-1.5.2.js</js>
     <js included="aggregated" resource="true">/rs/underscore/1.5.2/underscore-1.5.2.min.js</js>

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/common_skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/common_skin.xml
@@ -57,8 +57,8 @@
      | http://getbootstrap.com/javascript/#js-noconflict) and we can save the bootstrap functions to invoke them
      | manually.
      -->
-    <js included="plain" resource="true">/rs/fluid/pre1.5.0-6cb52a5083/js/fluid-custom.js</js>
-    <js included="aggregated" resource="true">/rs/fluid/pre1.5.0-6cb52a5083/js/fluid-custom.min.js</js>
+    <js included="plain" resource="true">/rs/fluid/1.5.0/js/fluid-custom.js</js>
+    <js included="aggregated" resource="true">/rs/fluid/1.5.0/js/fluid-custom.min.js</js>
 
     <js included="plain" resource="true">/rs/underscore/1.5.2/underscore-1.5.2.js</js>
     <js included="aggregated" resource="true">/rs/underscore/1.5.2/underscore-1.5.2.min.js</js>

--- a/uportal-war/src/main/webapp/media/skins/universality/coal/skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/universality/coal/skin.xml
@@ -27,12 +27,12 @@
   <parameter name="fss-theme">fl-theme-coal</parameter>
   
   <!-- Fluid Skinning System (FSS).  Includes a CSS reset for browser normalization. -->
-  <css included="plain">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-framework.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-framework.min.css</css>
+  <css included="plain">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-framework.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-framework.min.css</css>
   
   <!-- Fluid Skinning System (FSS) theme. -->
-  <css included="plain">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-theme-coal.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-theme-coal.min.css</css>
+  <css included="plain">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-theme-coal.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-theme-coal.min.css</css>
   
   <!-- Default jQuery UI theme.  Point this to a custom jQuery UI theme if desired. -->
   <css included="plain">/ResourceServingWebapp/rs/jqueryui/1.10.3/theme/ui-darkness/jquery-ui-1.10.3-darkness.css</css>

--- a/uportal-war/src/main/webapp/media/skins/universality/common/common_skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/universality/common/common_skin.xml
@@ -81,8 +81,8 @@
     <js included="plain" resource="true">/rs/backbone/1.0.0/backbone-1.0.0.js</js>
     <js included="aggregated" resource="true">/rs/backbone/1.0.0/backbone-1.0.0.min.js</js>
 
-    <js included="plain" resource="true">/rs/fluid/pre1.5.0-6cb52a5083/js/fluid-custom.js</js>
-    <js included="aggregated" resource="true">/rs/fluid/pre1.5.0-6cb52a5083/js/fluid-custom.min.js</js>
+    <js included="plain" resource="true">/rs/fluid/1.5.0/js/fluid-custom.js</js>
+    <js included="aggregated" resource="true">/rs/fluid/1.5.0/js/fluid-custom.min.js</js>
 
     <!-- Data Table Includes -->
     <js included="plain" resource="true">/rs/datatables/1.9.4/media/js/jquery.dataTables.js</js>

--- a/uportal-war/src/main/webapp/media/skins/universality/hc/skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/universality/hc/skin.xml
@@ -27,8 +27,8 @@
   <!--parameter name="fss-theme">fl-theme-hc</parameter-->
   
   <!-- Fluid Skinning System (FSS).  Includes a CSS reset for browser normalization. -->
-  <css included="plain">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-framework.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-framework.min.css</css>
+  <css included="plain">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-framework.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-framework.min.css</css>
   
   <!-- Default jQuery UI theme.  Point this to a custom jQuery UI theme if desired. -->
   <css>jquery-ui-1.7.2.custom/css/custom-theme/jquery-ui-1.7.2.custom.css</css>

--- a/uportal-war/src/main/webapp/media/skins/universality/ivy/skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/universality/ivy/skin.xml
@@ -27,12 +27,12 @@
   <parameter name="fss-theme">fl-theme-mist</parameter>
   
   <!-- Fluid Skinning System (FSS).  Includes a CSS reset for browser normalization. -->
-  <css included="plain">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-framework.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-framework.min.css</css>
+  <css included="plain">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-framework.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-framework.min.css</css>
   
   <!-- Fluid Skinning System (FSS) theme. -->
-  <css included="plain">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-theme-mist.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-theme-mist.min.css</css>
+  <css included="plain">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-theme-mist.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-theme-mist.min.css</css>
   
   <!-- Default jQuery UI theme.  Comment this out if you are using your own custom jQuery UI theme. -->
   <css included="plain">/ResourceServingWebapp/rs/jqueryui/1.10.3/theme/smoothness/jquery-ui-1.10.3-smoothness.css</css>

--- a/uportal-war/src/main/webapp/media/skins/universality/uportal3/skin.xml
+++ b/uportal-war/src/main/webapp/media/skins/universality/uportal3/skin.xml
@@ -27,12 +27,12 @@
   <parameter name="fss-theme">fl-theme-mist</parameter>
   
   <!-- Fluid Skinning System (FSS).  Includes a CSS reset for browser normalization. -->
-  <css included="plain">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-framework.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-framework.min.css</css>
+  <css included="plain">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-framework.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-framework.min.css</css>
   
   <!-- Fluid Skinning System (FSS) theme. -->
-  <css included="plain">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-theme-mist.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/fluid/pre1.5.0-6cb52a5083/fss/css/fss-theme-mist.min.css</css>
+  <css included="plain">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-theme-mist.css</css>
+  <css included="aggregated">/ResourceServingWebapp/rs/fluid/1.5.0/fss/css/fss-theme-mist.min.css</css>
   
   <!-- Default jQuery UI theme.  Point this to a custom jQuery UI theme if desired. -->
   <css included="plain">/ResourceServingWebapp/rs/jqueryui/1.10.3/theme/smoothness/jquery-ui-1.10.3-smoothness.css</css>


### PR DESCRIPTION
I performed basic testing; universality, Respondr, and mobile seem to be fine.  Drag and drop works (UP-4000 not fixed) for portlets and tabs.  General layout and navigation works. Manage Groups/Users works, email preview works. Tested the items I recall fluid 1.4.0 to 1.5.0 gave us trouble with.

It would be great to get some additional testing, but my initial testing is this can be included in uPortal 4.1.0 GA.

FYI fluid 1.5.0 released about 7 days ago.
