### PR TITLE
UP-3896 Un-favoriting the last favorite return to VIEW mode.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlets/favorites/FavoritesEditController.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/favorites/FavoritesEditController.java
@@ -32,6 +32,7 @@ import org.springframework.web.portlet.bind.annotation.ActionMapping;
 import org.springframework.web.portlet.bind.annotation.RenderMapping;
 
 import javax.portlet.ActionResponse;
+import javax.portlet.PortletMode;
 import javax.portlet.RenderRequest;
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -114,6 +115,7 @@ public class FavoritesEditController
     /**
      * Un-favorite a favorite node (portlet or collection) identified by node ID.
      * Routed by the action=delete parameter.
+     * If no favorites remain after un-favoriting, switches portlet mode to VIEW.
      *
      * Sets render parameters:
      * successMessageCode: message code of success message if applicable
@@ -125,7 +127,7 @@ public class FavoritesEditController
      * nameOfFavoriteActedUpon and action will always be set.
      *
      * @param nodeId identifier of target node
-     * @param response ActionResponse onto which render parameters will be set
+     * @param response ActionResponse onto which render parameters will, mode may, be set
      */
     @ActionMapping(params = {"action=delete"})
     public void unFavoriteNode(@RequestParam("nodeId") String nodeId, ActionResponse response) {
@@ -151,6 +153,13 @@ public class FavoritesEditController
                     layoutManager.saveUserLayout();
 
                     response.setRenderParameter("successMessageCode", "favorites.unfavorite.success.parameterized");
+
+                    IUserLayout updatedLayout = layoutManager.getUserLayout();
+
+                    // if removed last favorite, return to VIEW mode
+                    if (! FavoritesUtils.hasAnyFavorites(updatedLayout)) {
+                        response.setPortletMode(PortletMode.VIEW);
+                    }
 
                     logger.debug("Successfully unfavorited [{}]", nodeDescription);
 

--- a/uportal-war/src/main/java/org/jasig/portal/portlets/favorites/FavoritesUtils.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlets/favorites/FavoritesUtils.java
@@ -19,6 +19,7 @@
 
 package org.jasig.portal.portlets.favorites;
 
+import org.apache.commons.lang3.Validate;
 import org.jasig.portal.layout.IUserLayout;
 import org.jasig.portal.layout.node.IUserLayoutFolderDescription;
 import org.jasig.portal.layout.node.IUserLayoutNodeDescription;
@@ -205,5 +206,20 @@ public final class FavoritesUtils {
         logger.debug("Extracted favorite portlets [{}] from [{}]", favorites, userLayout);
 
         return favorites;
+    }
+
+
+    /**
+     * True if the layout contains any favorited collections or favorited individual portlets, false otherwise.
+     * @param layout non-null user layout that might contain favorite portlets and/or collections
+     * @return true if the layout contains at least one favorited portlet or collection, false otherwise
+     * @throws IllegalArgumentException if layout is null
+     */
+    public static boolean hasAnyFavorites(IUserLayout layout) {
+        Validate.notNull(layout, "Cannot determine whether a null layout contains favorites.");
+
+        // (premature) performance optimization: short circuit returns true if nonzero favorite portlets
+        return (!getFavoritePortlets(layout).isEmpty() || !getFavoriteCollections(layout).isEmpty() );
+
     }
 }


### PR DESCRIPTION
Without this change, un-favoriting the last favorite leaves you in edit mode with nothing to edit.

With this change, instead, un-favoriting the last favorite returns you to view mode.

Editing that last favorite:

![](http://cl.ly/image/2E0o0z2z0l36/Image%202014-06-25%20at%206.34.13%20AM.png)

After removing the last favorite, with this change:

![](http://cl.ly/image/3i2v112E3s2G/Image%202014-06-25%20at%206.34.31%20AM.png)
## Implementation notes:
### Did not include remove confirmation in view mode.

Considered the you have no favorites messaging and experience as sufficient confirmation that the item to be removed was removed.  This is questionable user experience design -- it might be better to echo back to the user a notification of exactly what was removed.  Maybe revisit this when implementing undo control on those notifications such that those notifications are more valuable.
### There's still an edit_zero view

While the user now goes right back to view mode when deleting that last favorite, they can still get back to edit mode e.g. through the portal chrome.  So, that view is still there and still needs to be maintained even though removing the last favorite no longer immediately goes there.
### No JIRA for this feature specifically

Since Favorites is not yet in any actual released version of uPortal, tracked this under auspices of the overall Favorites feature JIRA rather than creating another issue to track this feature specifically.
### Static stateless helper vs richer domain model

Continued using the `FavoritesUtils` static stateless helper, which is cute and all, but maybe Favorites methods should be added to the `IUserLayout` interface itself so as to have a richer domain model and call `layout.hasFavorites()` rather than `FavoritesUtils.hasFavorites(layout)`.  Perhaps a refactor to make for a uPortal 4.2 release where Favorites will have more miles on the tires and have become a more established uPortal feature.
### No unit tests

Would be good to have 'em.  Layouts are complicated to test, but that's not a great excuse.
