### PR TITLE
Adds html decoding to clientside mktplace entries

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/portlet/entry.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Marketplace/portlet/entry.jsp
@@ -435,13 +435,18 @@ up.jQuery(function() {
                 }
             }
         }
+        var htmlDecode = function(input){
+            var e = document.createElement('div');
+            e.innerHTML = input;
+            return e.childNodes.length === 0 ? "" : e.childNodes[0].nodeValue;
+        };
         if($("#${n}marketplace_user_rating").val().length>0){
             $("#${n}marketplace_user_rating_submit_button").removeClass("disabled");
             updateRatingInstructions('<spring:message code="rating.instructions.rated"
                 text='You have already rated "{0}"; adjust your rating if you wish.'
                 arguments="${portlet.title}"
                 htmlEscape="true" />');
-            $("#${n}marketplace_user_review_input").val("<c:out value="${marketplaceRating.review}"/>");
+            $("#${n}marketplace_user_review_input").val(htmlDecode("<c:out value="${marketplaceRating.review}"/>"));
         }else{
             updateRatingInstructions('<spring:message code="rating.instructions.unrated"
                 text='You have not yet rated "{0}".'


### PR DESCRIPTION
We obviously protect ourselves from user input.  We escape our output to the page (part of XSS prevention).  This commit will render it back to user-readable content.

After:
![image](https://cloud.githubusercontent.com/assets/5521429/3416938/816be210-fe32-11e3-9519-9608b724a46d.png)

Before:
![image](https://cloud.githubusercontent.com/assets/5521429/3416943/9b946284-fe32-11e3-9dd8-719c474bff7e.png)
