### PR TITLE
UP-4056 Remove attempting password retrieval multiple times

### DIFF
--- a/uportal-portlets-overlay/cas/pom.xml
+++ b/uportal-portlets-overlay/cas/pom.xml
@@ -161,6 +161,13 @@
                 <filtering>true</filtering>
                 <directory>src/main/resources</directory>
             </resource>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/webapp/WEB-INF</directory>
+                <includes>
+                    <include>cas.properties</include>
+                </includes>
+            </resource>
         </resources>
         <plugins>
             <plugin>

--- a/uportal-portlets-overlay/cas/src/main/webapp/WEB-INF/cas.properties
+++ b/uportal-portlets-overlay/cas/src/main/webapp/WEB-INF/cas.properties
@@ -19,8 +19,8 @@
 
 ##
 # Services Management Web UI Security
-server.name=http://localhost:8080
-server.prefix=${server.name}/cas
+server.name=${environment.build.cas.protocol}://${environment.build.cas.server}
+server.prefix=${server.name}${environment.build.cas.context}
 cas.securityContext.serviceProperties.service=${server.prefix}/services/j_acegi_cas_security_check
 # Names of roles allowed to access the CAS service manager
 cas.securityContext.serviceProperties.adminRoles=ROLE_ADMIN

--- a/uportal-portlets-overlay/cas/src/main/webapp/WEB-INF/spring-configuration/clearpass-configuration.xml
+++ b/uportal-portlets-overlay/cas/src/main/webapp/WEB-INF/spring-configuration/clearpass-configuration.xml
@@ -86,7 +86,7 @@
     <property name="ticketValidator">
       <bean class="org.jasig.cas.client.validation.Cas20ProxyTicketValidator">
         <constructor-arg index="0" value="${server.prefix}" />
-        <property name="acceptAnyProxy" value="true" />
+        <property name="acceptAnyProxy" value="true" />  <!-- Do NOT deploy to production this way. Use clearPassProxyList -->
       </bean>
     </property>
   </bean>

--- a/uportal-war/src/main/java/org/jasig/portal/security/provider/cas/clearpass/PasswordCachingCasAssertionSecurityContext.java
+++ b/uportal-war/src/main/java/org/jasig/portal/security/provider/cas/clearpass/PasswordCachingCasAssertionSecurityContext.java
@@ -18,14 +18,9 @@
  */
 package org.jasig.portal.security.provider.cas.clearpass;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
 import org.jasig.cas.client.util.CommonUtils;
 import org.jasig.cas.client.util.XmlUtils;
 import org.jasig.cas.client.validation.Assertion;
-import org.jasig.portal.properties.PropertiesManager;
 import org.jasig.portal.security.IOpaqueCredentials;
 import org.jasig.portal.security.provider.NotSoOpaqueCredentials;
 import org.jasig.portal.security.provider.cas.CasAssertionSecurityContext;
@@ -36,130 +31,75 @@ import org.springframework.util.Assert;
  */
 public class PasswordCachingCasAssertionSecurityContext extends CasAssertionSecurityContext {
 
-    private static final ScheduledExecutorService executor = Executors.newScheduledThreadPool(5);
-    private static final int MAX_PASSWORD_RETRIEVAL_RETRY_ATTEMPTS = 5;
-    private static final long PASSWORD_RETRIEVAL_DELAY = 300;
-    private static final String PROPERTY_PASSWORD_RETRIEVAL_DELAY =
-            "org.jasig.portal.security.provider.cas.clearpass.retryDelay";
-    private static final String PROPERTY_PASSWORD_RETRIEVAL_MAX_RETRY_ATTEMPTS =
-            "org.jasig.portal.security.provider.cas.clearpass.maxRetryAttempts";
     private static final long serialVersionUID = -3816036745827152340L;
 
     private final String clearPassUrl;
 
-    // Must use synchronized for access to insure the thread attempting to return credentials
-    // sees updates made by the thread pool thread (or must be made volatile).
     private byte[] cachedCredentials;
-
-    private Assertion assertion;
-    private String proxyTicket;
-
-    // Count of number of times we've attempted to retrieve user's password
-    private int passwordRetrievalCount;
-    // Delay in ms before attempting to automatically retrieve user's password again
-    private long passwordRetrievalDelay;
-    // Maximum number of times to try to automatically retrieve the user's password
-    private int passwordRetrievalMaxRetryAttempts;
 
     protected PasswordCachingCasAssertionSecurityContext(final String clearPassUrl) {
         super();
         Assert.notNull(clearPassUrl, "clearPassUrl cannot be null.");
         this.clearPassUrl = clearPassUrl;
-        passwordRetrievalDelay = PropertiesManager.getPropertyAsLong
-                (PROPERTY_PASSWORD_RETRIEVAL_DELAY, PASSWORD_RETRIEVAL_DELAY);
-        passwordRetrievalMaxRetryAttempts = PropertiesManager.getPropertyAsInt
-                (PROPERTY_PASSWORD_RETRIEVAL_MAX_RETRY_ATTEMPTS, MAX_PASSWORD_RETRIEVAL_RETRY_ATTEMPTS);
     }
 
     @Override
     protected final void postAuthenticate(final Assertion assertion) {
-
-        this.assertion = assertion;
-        retrievePasswordFromCasServer();
+        retrievePasswordFromCasServer(assertion);
     }
 
     @Override
     public final IOpaqueCredentials getOpaqueCredentials() {
-        byte[] password = retrievePasswordFromCasServer();
-        if (password == null) {
+        if (this.cachedCredentials == null) {
             return super.getOpaqueCredentials();
         }
 
         final NotSoOpaqueCredentials credentials = new CacheOpaqueCredentials();
-        credentials.setCredentials(password);
+        credentials.setCredentials(this.cachedCredentials);
         return credentials;
     }
 
     /**
      * Attempt to use the PGTIOU returned in the service ticket validation to obtain a proxy ticket to call CAS
-     * to get the user's password.  The Proxy Granting Ticket IOU (PGTIOU) is present in the assertion.
-     * CAS delivers the Proxy Granting Ticket (PGT) to one of the uPortal servers. Since the PGT may not be
-     * delivered to this uPortal node, if password retrieval fails attempt again a few times after waiting a
-     * bit to give the PGT a chance to get replicated to this uPortal node via distributed cache.
-     *
-     * <p>This method may potentially be called by multiple threads simultaneously so insure only one simultaneous
-     * attempt is made to contact the CAS server to get the password.
+     * to get the user's password.  The Proxy Granting Ticket IOU (PGTIOU) from the service ticket validation response
+     * has already been matched to the Proxy Granting Ticket (PGT) that CAS delivers to one of the uPortal servers
+     * and the PGT should be present in the assertion. If password retrieval fails, log messages to help the user
+     * identify the issue.  It may be that the uPortal servers are in a cluster and the configuration is not correct
+     * so this uPortal server does not have the PGT.
      *
      * <p>NOTE: This method will update <code>cachedCredentials</code> so the caller does not need to.
      *
-     * @return Bytes representing the user's password.  Null if not available.
+     * @param assertion CAS Assertion
+     * @return Bytes representing the user's password.  Null if not available. cachedCredentials is also updated
      */
-    protected synchronized byte[] retrievePasswordFromCasServer() {
-        // If we do not have the password, attempt to retrieve it.
-        if (cachedCredentials == null) {
-            // Get the Proxy Granting Ticket (PGTIOU) from the assertion and use it to get a proxy ticket
-            // to obtain the user's password.
-            if (proxyTicket == null) {
-                log.debug("Attempting to get CAS ClearPass Proxy Ticket for user {} using PGTIOU in assertion",
-                        assertion.getPrincipal().getName());
-                proxyTicket = assertion.getPrincipal().getProxyTicketFor(this.clearPassUrl);
-            }
+    protected byte[] retrievePasswordFromCasServer(Assertion assertion) {
+        // Get the Proxy Granting Ticket from the assertion and use it to obtain the user's password.
+        log.debug("Attempting to get CAS ClearPass Proxy Ticket for user {} using PGTIOU in assertion",
+                assertion.getPrincipal().getName());
+        String proxyTicket = assertion.getPrincipal().getProxyTicketFor(this.clearPassUrl);
 
-            // If we were able to get the proxy ticket (it was delivered to this server or replicated to this server),
-            // invoke CAS to retrieve the password.
-            if (proxyTicket != null) {
-                log.debug("Attempting to get password for user {} using Proxy Ticket {}",
-                        assertion.getPrincipal().getName(), proxyTicket);
+        // If we were able to get the proxy ticket (it was delivered to this server or replicated to this server),
+        // invoke CAS to retrieve the password.
+        if (proxyTicket != null) {
+            log.debug("Attempting to get password for user {} using Proxy Ticket {}",
+                    assertion.getPrincipal().getName(), proxyTicket);
 
-                String password = retrievePasswordUsingProxyTicket(proxyTicket);
+            String password = retrievePasswordUsingProxyTicket(proxyTicket);
 
-                if (password != null) {
-                    log.debug("Password retrieved from ClearPass.");
-                    this.cachedCredentials = password.getBytes();
-                }
-            }
-
-            // If we still don't have the credentials, determine if we should try again later.  The uPortal
-            // login process takes long enough we typically will have time for the replication to occur before
-            // we need the credentials.
-            if (cachedCredentials == null) {
-                // If the proxy ticket is not available because it was sent to another server and hasn't replicated
-                // to this server yet, or if the password retrieval from CAS failed for some reason we'll
-                // try again a bit later if we haven't exceeded the max retrieval attempts setting.
-                String message = proxyTicket == null ? "proxy ticket" : "password";
-                if (++passwordRetrievalCount > passwordRetrievalMaxRetryAttempts) {
-                    // NOTE:  Each time a portlet requiring a password renders it will attempt to obtain the
-                    // password so this error message may appear many times with counts greatly exceeding
-                    // passwordRetrievalMaxRetryAttempts since they are not automatic retries but valid attempts
-                    // to get the password.
-                    log.error("Unable to obtain {} for {} from CAS ClearPass in {} attempts. Check your"
-                            + " uPortal and CAS configuration.  See uPortal manual section on Caching and"
-                            + " Replaying credentials", message, assertion.getPrincipal().getName(),
-                            passwordRetrievalCount);
-                } else {
-                    log.info("Unable to obtain {} for {} from CAS ClearPass. Will try again {} more times {}",
-                            message, assertion.getPrincipal().getName(),
-                            passwordRetrievalMaxRetryAttempts - passwordRetrievalCount + 1,
-                            proxyTicket == null ? " for PGT to replicate to this server through distributed cache"
-                                : "");
-                    executor.schedule(new ObtainPasswordWorker(this), passwordRetrievalDelay, TimeUnit.MILLISECONDS);
-                }
+            if (password != null) {
+                log.debug("Password retrieved from ClearPass.");
+                this.cachedCredentials = password.getBytes();
             }
         }
-        return cachedCredentials;
-    }
 
-    private synchronized byte[] getCachedCredentials() {
+        if (cachedCredentials == null) {
+            // If the proxy ticket is not available because it was sent to another server and hasn't replicated to this
+            // server yet, or if the password retrieval from CAS failed for some reason we'll log a message.
+            log.error("Unable to obtain {} for {} from CAS ClearPass. Check your"
+                    + " uPortal and CAS configuration.  See uPortal manual section on Caching and"
+                    + " Replaying credentials", proxyTicket == null ? "proxy ticket" : "password",
+                    assertion.getPrincipal().getName());
+        }
         return cachedCredentials;
     }
 
@@ -181,11 +121,9 @@ public class PasswordCachingCasAssertionSecurityContext extends CasAssertionSecu
             return null;
         } catch (Exception e) {
             /*
-             * uPortal failed to obtain the user's password from the ClearPass
-             * feature.  This issue commonly occurs in local dev environments
-             * because CAS will not share the user's credential over a non-SSL
-             * connection.  We need to log this event, but should not fail the
-             * whole AuthN.
+             * uPortal failed to obtain the user's password from the ClearPass feature.  This issue commonly occurs
+             * in local dev environments because CAS will not share the user's credential over a non-SSL
+             * connection.  We need to log this event, but should not fail the whole Authentication.
              */
             if (log.isWarnEnabled()) {
                 log.warn("Unable to retrieve the credential from the ClearPass " +
@@ -215,19 +153,4 @@ public class PasswordCachingCasAssertionSecurityContext extends CasAssertionSecu
 		}
 	}
 
-    private class ObtainPasswordWorker implements Runnable {
-        PasswordCachingCasAssertionSecurityContext context;
-
-        ObtainPasswordWorker(PasswordCachingCasAssertionSecurityContext context) {
-            this.context = context;
-        }
-
-        /**
-         * Attempt to retrieve the password from the CAS Server if it has not already been obtained.
-         */
-        @Override
-        public void run() {
-            retrievePasswordFromCasServer();
-        }
-    }
 }

--- a/uportal-war/src/main/resources/properties/contexts/portletContainerContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/portletContainerContext.xml
@@ -112,7 +112,7 @@
      | By default it is commented out as a security precaution to prevent portlets from having access
      | to the password information unless an institution determines they want to enable that capability.
      | NOTE:  Other configuration is also needed to obtain and cache the user's password so this bean can provide it.
-     | See the uPortal manual https://wiki.jasig.org/display/UPM40/Caching+and+Re-playing+Credentials.
+     | See the uPortal manual https://wiki.jasig.org/display/UPM41/Caching+and+Re-playing+Credentials.
      -->
     <!--bean id="cachedPasswordUserInfoService"
         class="org.jasig.portal.portlet.container.services.CachedPasswordUserInfoService">

--- a/uportal-war/src/main/resources/properties/portal.properties
+++ b/uportal-war/src/main/resources/properties/portal.properties
@@ -487,24 +487,6 @@ org.jasig.portal.portlets.googleWebSearch.search.result.type=googleCustom
 org.jasig.portal.portlets.passwordEncryptionKey=changeme
 
 ##
-## Duration in milliseconds between attempts to retrieve the user's password from CAS ClearPass (if enabled).
-## In a clustered uPortal environment, the CAS Server may deliver the Proxy Granting Ticket (PGT) to a different
-## uPortal server so it may not be available when the uPortal server the user is interacting with is completing
-## the authentication process.  The password won't be needed for some time afterward (until attempting to
-## invoke a portlet that is configured to use the user's password) so uPortal has time to retry obtaining the
-## user's password before the PGT expires.  Ideally this value is long enough to give the PGT time to replicate
-## through distributed cache to the uPortal server the user is on, plus give uPortal time to make the two server
-## invocations to CAS to get the proxy ticket and then the password before the password is needed so it does not
-## slow down the threads attempting to render portlets needing the password.
-##
-org.jasig.portal.security.provider.cas.clearpass.retryDelay=300
-
-##
-## Number of attempts to automatically retrieve the user's password from CAS Clearpass (if enabled).
-##
-org.jasig.portal.security.provider.cas.clearpass.maxRetryAttempts=5
-
-##
 ## Controls the user that represents a "Guest" user in the portal.
 ## Users are considered guests when they have this user name and
 ## they are not authenticated with the portal.


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4056

Found out that if PGT was not in cache before PasswordCachingCasAssertionSecurityContext is invoked, retrying multiple times won't matter because assertion won't contain the PGT.  Removing extraneous code to avoid confusion.
