### PR TITLE
NO JIRA Adds window state option to menu URLs

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -344,6 +344,13 @@
     <div class="btn-group">
       <a class="btn btn-link dropdown-toggle" data-toggle="dropdown" href="#"><xsl:value-of select="upMsg:getMessage('portlet.menu.option', $USER_LANG)"/> <span class="{upMsg:getMessage('portlet.menu.option.caretclass', $USER_LANG)}"></span></a>
       <ul class="dropdown-menu" style="right: 0; left: auto;">
+      <!--
+          Window State: MAXIMIZED/MINIMIZED/NORMAL to open the urls in the
+          contextual menu.  Leaving blank will continue to the current behavior
+          of keeping the current window state on a mode switch.
+      -->
+      <xsl:variable name="portalURLState">
+      </xsl:variable>
     <!--
       Porlet Controls Display Order:
       help, remove, maximize, minimize, info, print, settings, ...
@@ -386,7 +393,7 @@
             <xsl:with-param name="url">
                 <url:portal-url>
                     <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="HELP" copyCurrentRenderParameters="true" />
+                    <url:portlet-url state="$portalURLState" mode="HELP" copyCurrentRenderParameters="true" />
                 </url:portal-url>
             </xsl:with-param>
           </xsl:call-template>
@@ -490,7 +497,7 @@
             <xsl:with-param name="url">
                 <url:portal-url>
                     <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="ABOUT" copyCurrentRenderParameters="true" />
+                    <url:portlet-url state="$portalURLState" mode="ABOUT" copyCurrentRenderParameters="true" />
                 </url:portal-url>
             </xsl:with-param>
           </xsl:call-template>
@@ -507,7 +514,7 @@
             <xsl:with-param name="url">
                 <url:portal-url>
                     <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="EDIT" copyCurrentRenderParameters="true" />
+                    <url:portlet-url state="$portalURLState" mode="EDIT" copyCurrentRenderParameters="true" />
                 </url:portal-url>
             </xsl:with-param>
           </xsl:call-template>
@@ -525,7 +532,7 @@
               <xsl:with-param name="url">
                   <url:portal-url>
                       <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                      <url:portlet-url mode="CONFIG" copyCurrentRenderParameters="true" />
+                      <url:portlet-url state="$portalURLState" mode="CONFIG" copyCurrentRenderParameters="true" />
                   </url:portal-url>
               </xsl:with-param>
             </xsl:call-template>
@@ -543,7 +550,7 @@
             <xsl:with-param name="url">
                 <url:portal-url>
                     <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="PRINT" copyCurrentRenderParameters="true" />
+                    <url:portlet-url state="$portalURLState" mode="PRINT" copyCurrentRenderParameters="true" />
                 </url:portal-url>
             </xsl:with-param>
           </xsl:call-template>

--- a/uportal-war/src/main/resources/layout/theme/universality/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/content.xsl
@@ -257,6 +257,13 @@
   <!-- This template renders portlet controls.  Each control has a unique class for assigning icons or other specific presentation. -->
   <xsl:template name="controls">
     <div class="up-portlet-controls">
+      <!--
+          Window State: MAXIMIZED/MINIMIZED/NORMAL to open the urls in the
+          contextual menu.  Leaving blank will continue to the current behavior
+          of keeping the current window state on a mode switch.
+      -->
+      <xsl:variable name="portalURLState">
+      </xsl:variable>
       <xsl:variable name="hasHelp">
           <xsl:if test="parameter[@name='hasHelp'] and parameter[@name='hasHelp']/@value = 'true'">true</xsl:if>
       </xsl:variable>
@@ -275,7 +282,7 @@
             <xsl:with-param name="url">
                 <url:portal-url>
                     <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="HELP" copyCurrentRenderParameters="true" />
+                    <url:portlet-url state="$portalURLState" mode="HELP" copyCurrentRenderParameters="true" />
                 </url:portal-url>
             </xsl:with-param>
           </xsl:call-template>
@@ -293,7 +300,7 @@
             <xsl:with-param name="url">
                 <url:portal-url>
                     <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="ABOUT" copyCurrentRenderParameters="true" />
+                    <url:portlet-url state="$portalURLState" mode="ABOUT" copyCurrentRenderParameters="true" />
                 </url:portal-url>
             </xsl:with-param>
           </xsl:call-template>
@@ -311,7 +318,7 @@
             <xsl:with-param name="url">
                 <url:portal-url>
                     <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="EDIT" copyCurrentRenderParameters="true" />
+                    <url:portlet-url state="$portalURLState" mode="EDIT" copyCurrentRenderParameters="true" />
                 </url:portal-url>
             </xsl:with-param>
           </xsl:call-template>
@@ -329,7 +336,7 @@
             <xsl:with-param name="url">
                 <url:portal-url>
                     <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                    <url:portlet-url mode="PRINT" copyCurrentRenderParameters="true" />
+                    <url:portlet-url state="$portalURLState" mode="PRINT" copyCurrentRenderParameters="true" />
                 </url:portal-url>
             </xsl:with-param>
           </xsl:call-template>


### PR DESCRIPTION
Madison needed the option to open some/all links in the options menu in MAXIMIZED state.  The links we were talking about were config/edit/help/about/etc.  If you leave the variable blank, the current state is preserved when switching modes.  So, this pull request adds functionality, but doesn't change any current behavior.

Anyone have any thoughts on this?
