### PR TITLE
[UP-3315] Fix some XSS issue around inputting usernames.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/utils/jsp/Util.java
+++ b/uportal-war/src/main/java/org/jasig/portal/utils/jsp/Util.java
@@ -20,19 +20,20 @@
 package org.jasig.portal.utils.jsp;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Map;
 
-import org.jasig.portal.spring.beans.factory.ObjectMapperFactoryBean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jasig.portal.spring.beans.factory.ObjectMapperFactoryBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.util.UriUtils;
+
 
 /**
  * JSP Static utility functions
@@ -112,5 +113,46 @@ public class Util {
             };
         }
         return isValid;
+    }
+
+
+    /**
+     * URL encode a path segment.  This is just a thin wrapper around UriUtils.encodePathSegment.  It is intended
+     * for the case where you are building URLs in JS.  c:url + escapeBody doesn't correctly escape
+     * the contents (especially "</script>"), and fn:escapeXml incorrectly encodes the URL (it escapes chars
+     * like '<' as &lt; instead of %3C).  It should help avoid XSS attacks when building RESTful
+     * URLS in js.  Example:
+     *
+     * Given:  ${userId} -> "<script>alert('test')</script>
+     *
+     * ...
+     * <script>
+     *     $.ajax({ url: <c:url value='/users/${up:encodePathSegment(userId)}'/> });
+     * </script>
+     *
+     * Will encode the URL as:
+     *
+     * /users/%3Cscript%3Ealert('test%')%3C%2Fscript%3E
+     *
+     * IMPORTANT:
+     * Note that this encodes the '/' in </script>  to %2F.  Unfortunately, tomcat
+     * still does not interpret %2F correctly unless you relax some security
+     * settings (@see tomcat.apache.org/tomcat-7.0-doc/config/systemprops.html#Security,
+     * the ALLOW_ENCODED_SLASH property).  So, while this method does a better job
+     * at avoiding XSS issues than c:url, it's still not ideal.  Unless the
+     * input is whitelisted to avoid invalid input chars, it's still possible to
+     * end up with REST URLs that won't work correctly (like the one above), but at
+     * least this will protect you from XSS attacks on the front end.
+     *
+     * @param val the path segment to encode
+     * @return the encoded path segment
+     */
+    public static String encodePathSegment(String val) {
+        try {
+            return UriUtils.encodePathSegment(val, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // should be unreachable...
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/uportal-war/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/edit-group/viewGroupPermissions.jsp
@@ -184,7 +184,7 @@ up.jQuery(function() {
             table : null,
             pageSize: 10
         },
-        url: "<c:url value="/api/assignments/principal/${ principalString }.json?includeInherited=true"/>",
+        url: "<c:url value="/api/assignments/principal/${ up:encodePathSegment(principalString) }.json?includeInherited=true"/>",
         searchExclude: 1, //Exclude principal
         showPrincipal: false,
         showTarget: true
@@ -201,7 +201,7 @@ up.jQuery(function() {
             table : null,
             pageSize: 10
         },
-        url: "<c:url value="/api/assignments/target/${ principalString }.json?includeInherited=true"/>",
+        url: "<c:url value="/api/assignments/target/${ up:encodePathSegment(principalString) }.json?includeInherited=true"/>",
         searchExclude: 3, //Exclude target
         showPrincipal: true,
         showTarget: false

--- a/uportal-war/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/user-manager/viewPermissions.jsp
@@ -1,4 +1,4 @@
-<%--
+<%-
 
     Licensed to Jasig under one or more contributor license
     agreements. See the NOTICE file distributed with this work
@@ -184,7 +184,7 @@ up.jQuery(function() {
             table : null,
             pageSize: 10
         },
-        url: "<c:url value="/api/assignments/principal/${ personEntity.principalString }.json?includeInherited=true"/>",
+        url: "<c:url value="/api/assignments/principal/${ up:encodePathSegment(personEntity.principalString) }.json?includeInherited=true"/>",
         searchExclude: 1, //Exclude principal
         showPrincipal: false,
         showTarget: true
@@ -201,7 +201,7 @@ up.jQuery(function() {
             table : null,
             pageSize: 10
         },
-        url: "<c:url value="/api/assignments/target/${ personEntity.principalString }.json?includeInherited=true"/>",
+        url: "<c:url value="/api/assignments/target/${ up:encodePathSegment(personEntity.principalString) }.json?includeInherited=true"/>",
         searchExclude: 3, //Exclude target
         showPrincipal: true,
         showTarget: false

--- a/uportal-war/src/main/webapp/WEB-INF/tag/uportal.tld
+++ b/uportal-war/src/main/webapp/WEB-INF/tag/uportal.tld
@@ -128,4 +128,16 @@
             ${up:isValidUrl("www.example.com/image.png")}
         </example>
     </function>
+    <function>
+        <description>
+            URL encodes a single path segment.  Intended for building RESTful URLs where
+            variable values may contain illegal characters.
+        </description>
+        <name>encodePathSegment</name>
+        <function-class>org.jasig.portal.utils.jsp.Util</function-class>
+        <function-signature>java.lang.String encodePathSegment(java.lang.String)</function-signature>
+        <example>
+            ${up:urlEncode("www.example.com/image.png")}
+        </example>
+    </function>
 </taglib>


### PR DESCRIPTION
The issue was occurring because `</script>` always terminates the JS block -- even if that's inside a string.  The JS interpreter would terminate the block and then misinterpret the unterminated contents of the string as executable code.  The _right_ solution for this is probably to start whitelisting the input characters for every input field. Any field that will be part of a RESTful URL should not be allowed to contain the `/` character.  The "solution" in this commit is intended as a stop-gap.  It solves this biggest issue -- the XSS vulnerability -- but it doesn't fully solve the issues caused by invalid chars in the input.  IMO, this is better than what we had, but still not great.
