### PR TITLE
UP-4165: Add Google Analytics to muniversality

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/muniversality/muniversality.xsl
+++ b/uportal-war/src/main/resources/layout/theme/muniversality/muniversality.xsl
@@ -310,6 +310,7 @@
               <xsl:with-param name="path" select="$SKIN_RESOURCES_PATH" />
             </xsl:call-template>
 
+            <xsl:copy-of select="//channel[@fname = 'google-analytics-config']"/>
             <xsl:call-template name="page.js" />
         </head>
         <body class="up {$FLUID_THEME_CLASS} dashboard-{$VIEW}">


### PR DESCRIPTION
Google Analytics was present in the universality theme, but nowhere to be found in muniversality.
