### PR TITLE
UP-4170 allow Ant 1.9.3+.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ uPortal uses Travis-CI for lightweight continuous integration.  You can see buil
 * JDK 1.7 or later - Just a JRE is not sufficient, a full JDK is required
 * Servlet 2.5 Container - Tomcat 6.0 is recommended, there some configuration changes that must be made for Tomcat 6.0 which are documented in the [uPortal manual](https://wiki.jasig.org/display/UPM40/Installing+Tomcat).
 * Maven 3.0.3 or later
-* Ant 1.8.2
+* Ant 1.8.2 or 1.9.3 or later.
 
 ## Building and Deploying
 uPortal uses Maven for its project configuration and build system. An Ant
 build.xml is also provided which handles the initialization and deployment
 related tasks. As a uPortal deployer you will likely only ever need to use the
-Ant tasks. Ant 1.8.2 or later is required
+Ant tasks. Ant 1.8.2 or 1.9.3 or later is required
 
 ### Ant tasks (run "ant -p" for a full list) :
 

--- a/bootstrap/build_includes.xml
+++ b/bootstrap/build_includes.xml
@@ -22,11 +22,12 @@
 <project name="uPortal_Includes" basedir="." xmlns:artifact="urn:maven-artifact-ant">
     <dirname property="imported.basedir" file="${ant.file.uPortal_Includes}"/>
     
-    <fail message="1.8.2 is required, version ${ant.version} is not supported">
+    <fail message="Ant 1.8.2 or 1.9.3+ is required, version ${ant.version} is not supported">
         <condition>
             <not>
             	<or>
             	    <antversion exactly="1.8.2"/>
+                  <antversion atleast="1.9.3"/>
             	</or>
             </not>
         </condition>


### PR DESCRIPTION
While Ant `1.8.2` has historically been required for uPortal, Ant `1.9.3` seems to work.

See also [UP-4170](https://issues.jasig.org/browse/UP-4170).

Updates the build to not artificially fail on Ant 1.9.3 and the documentation to suggest 1.9.3 and later.  Leaves in explicit reference to 1.8.2 so that if (when) some post 1.9.3 version of Ant doesn't work again, there's the ready indication that 1.8.2 might be a safe Ant version to fall back to.

In practice adopters are going to try to use Ant 1.9.3 because that's an easy latest release to have handy from such things as Ubuntu package management.  This change should make uPortal less difficult to install for the happy path where the system version of Ant just works.
