### PR TITLE
UP-4171 : Update uPortal manual URLs to point to 4.1 version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-For more detailed help please refer to the [uPortal Manual](https://wiki.jasig.org/display/UPM40/Home)
+For more detailed help please refer to the [uPortal Manual](https://wiki.jasig.org/display/UPM41/Home)
 
 Additional information about uPortal is available on the [uPortal Home Page](http://www.apereo.org/uportal)
 or in the [uPortal Wiki](https://wiki.jasig.org/display/UPC/Home)
@@ -45,7 +45,7 @@ email address is the best place to go with questions related to configuring or
 deploying uPortal.    
 
 The uPortal manual is a collaborative document on the wiki which has more
-detailed documentation: https://wiki.jasig.org/display/UPM40
+detailed documentation: https://wiki.jasig.org/display/UPM41
 
 
 ## Other Notes

--- a/docs/docs-readme.txt
+++ b/docs/docs-readme.txt
@@ -23,7 +23,7 @@ Hey!  Where's the documentation?
 uPortal is documented in its wiki and its manual, not here in source control.
 
 uPortal manual:
-http://www.ja-sig.org/wiki/display/UPM40/Home
+http://www.ja-sig.org/wiki/display/UPM41/Home
 
 (Note: as of this writing the manual is a work in progress.  
 Your patience is appreciated, and your contributions would be most welcome.)

--- a/releaseNotes.html
+++ b/releaseNotes.html
@@ -61,7 +61,7 @@ issues discovered after this release went to press.
 <h2>Where to find documentation</h2>
 <ul>
 <li><a href="https://wiki.jasig.org/display/UPC/${project.version}">This release's wiki page, and its children pages</a></li>
-<li><a href="https://wiki.jasig.org/display/UPM40/">The uPortal Manual wiki space</a></li>
+<li><a href="https://wiki.jasig.org/display/UPM41/">The uPortal Manual wiki space</a></li>
 <li><a href="https://wiki.jasig.org/display/UPC/">The Jasig Wiki more generally</a></li>
 <li>The uPortal deployer and developer email list archives and ongoing discussions</li>
 </ul>


### PR DESCRIPTION
The uPortal 4.1 release documentation should point to the uPortal 4.1 version of the uPortal manual, rather than the 4.0 version.

See also [UP-4171](https://issues.jasig.org/browse/UP-4171).
