### PR TITLE
UP-4172 upgrade quickstart Tomcat and Maven to 7.0.54 and 3.0.5

### DIFF
--- a/assembly/build.properties
+++ b/assembly/build.properties
@@ -22,7 +22,7 @@ dl.apache-mirror=http://archive.apache.org/dist
 
 # Tomcat download configuration
 dl.tomcat.name=apache-tomcat
-dl.tomcat.version=7.0.32
+dl.tomcat.version=7.0.54
 dl.tomcat.format=tar.gz
 dl.tomcat.finalName=${dl.tomcat.name}-${dl.tomcat.version}
 dl.tomcat.file=${dl.tomcat.finalName}.${dl.tomcat.format}
@@ -39,7 +39,7 @@ dl.ant.url=${dl.apache-mirror}/ant/binaries/${dl.ant.file}
 
 #Maven download configuration
 dl.maven.name=apache-maven
-dl.maven.version=3.0.4
+dl.maven.version=3.0.5
 dl.maven.type=bin
 dl.maven.format=tar.gz
 dl.maven.finalName=${dl.maven.name}-${dl.maven.version}


### PR DESCRIPTION
See also [UP-4172](https://issues.jasig.org/browse/UP-4172).

Upgrade the quickstart Tomcat to 7.0.54 and the quickstart Maven to 3.0.5.
