### PR TITLE
UP-4205 CVE-2014-4172 Upgrade to Java CAS Client 3.3.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <ant.version>1.8.4</ant.version>
         <aspectjrt.version>1.7.3</aspectjrt.version>
         <aspectjweaver.version>1.7.3</aspectjweaver.version>
-        <casclient.version>3.2.1</casclient.version>
+        <casclient.version>3.3.2</casclient.version>
         <ccpp.version>1.0</ccpp.version>
         <cernunnos.version>1.2.2</cernunnos.version>
         <cglib.version>2.2.2</cglib.version>
@@ -748,6 +748,82 @@
                 <groupId>org.jasig.cas.client</groupId>
                 <artifactId>cas-client-core</artifactId>
                 <version>${casclient.version}</version>
+                
+                <exclusions>
+                  <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>org.apache.santuario</groupId>
+                    <artifactId>xmlsec</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>org.apache.santuario</groupId>
+                    <artifactId>xmlsec</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>opensaml</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>openws</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>org.opensaml</groupId>
+                    <artifactId>xmltooling</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>org.owasp.esapi</groupId>
+                    <artifactId>esapi</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jul-to-slf4j</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>velocity</groupId>
+                    <artifactId>velocity</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>xalan</groupId>
+                    <artifactId>serializer</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>xalan</groupId>
+                    <artifactId>xalan</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                  </exclusion>
+                  <exclusion>
+                    <groupId>xml-resolver</groupId>
+                    <artifactId>xml-resolver</artifactId>
+                  </exclusion>
+                </exclusions>
+                
             </dependency>
             <dependency>
                 <groupId>org.jasig.cas</groupId>


### PR DESCRIPTION
Upgrades uPortal `4.0-patches` to use Java CAS Client version `3.3.2`, which includes a fix for `CVE-2014-4172`.

Aggressively applies Maven excludes to keep the different transitive dependencies of Java CAS Client `3.3.2` (vs `3.2.1` previously used) out of the deployment.

Login seems to work.

Risks:
- Java CAS Client `3.3.2` [depends on Servlet API 3](https://issues.jasig.org/browse/CASC-230) which is [supported only in Tomcat 7](http://tomcat.apache.org/whichversion.html) and later.  uPortal 4.0.x up to this point has been trying to be Tomcat 6 compatible.  Tomcat 6 adopters may be annoyed.  Have not yet tested this to see whether it works anyway on Tomcat 6.

Is this the right fix for `4.0-patches` for a uPortal `4.0.15`?
