### PR TITLE
UP-4177 Add groovy-based duplication of username to user.login.id and uid if not present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <org.springframework.webflow.version>2.3.2.RELEASE</org.springframework.webflow.version>
         <oro.version>2.0.8</oro.version>
         <persistence-api.version>1.0</persistence-api.version>
-        <person-directory.version>1.5.2-M1</person-directory.version>
+        <person-directory.version>1.6.0</person-directory.version>
         <pluto.version>2.1.0-M3</pluto.version>
         <portlet-api.version>2.0</portlet-api.version>
         <quartz.version>2.2.1</quartz.version>
@@ -669,12 +669,22 @@
             </dependency>
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-ant</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-groovysh</artifactId>
                 <version>${groovy.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy-jsr223</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-test</artifactId>
                 <version>${groovy.version}</version>
             </dependency>
             <dependency>

--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -258,7 +258,12 @@
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>
         </dependency>
-        
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-ant</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-groovysh</artifactId>
@@ -507,12 +512,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jasig.service.persondir</groupId>
-            <artifactId>person-directory-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jasig.portal</groupId>
             <artifactId>uportal-platform-api</artifactId>
             <version>${project.version}</version>
@@ -635,6 +634,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>
@@ -711,6 +716,49 @@
             </resource>
         </resources>
         <plugins>
+            <!-- Compile groovy classes -->
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <target>
+                                <taskdef name="groovyc" classname="org.codehaus.groovy.ant.Groovyc">
+                                    <classpath refid="maven.compile.classpath" />
+                                </taskdef>
+                                <mkdir dir="${project.build.outputDirectory}" />
+                                <groovyc srcdir="${basedir}/src/main/groovy" destdir="${project.build.outputDirectory}" encoding="${project.build.sourceEncoding}">
+                                    <classpath refid="maven.compile.classpath" />
+                                </groovyc>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>generate-test-sources</phase>
+                        <configuration>
+                            <target>
+                                <taskdef name="groovyc" classname="org.codehaus.groovy.ant.Groovyc">
+                                    <classpath refid="maven.test.classpath" />
+                                </taskdef>
+                                <mkdir dir="${project.build.testOutputDirectory}" />
+                                <groovyc srcdir="${basedir}/src/test/groovy" destdir="${project.build.testOutputDirectory}" encoding="${project.build.sourceEncoding}">
+                                    <classpath refid="maven.test.classpath" />
+                                </groovyc>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>

--- a/uportal-war/src/main/groovy/org/jasig/portal/persondir/AttributeDuplicatingPersonAttributesScript.groovy
+++ b/uportal-war/src/main/groovy/org/jasig/portal/persondir/AttributeDuplicatingPersonAttributesScript.groovy
@@ -1,0 +1,66 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.persondir
+import org.jasig.services.persondir.support.BaseGroovyScriptDaoImpl
+/**
+ * Script that takes in an attribute key name to look for and if present in the passed in map of user attributes, copies
+ * the attribute's values to the provided list of attribute names if not already present.
+ * E.g. if an attribute called 'username' is present, add attributes uid and user.login.id if not present with the
+ * list of values of the username attribute.
+ *
+ * @author James Wennmacher, jwennmacher@unicon.net
+ */
+
+class AttributeDuplicatingPersonAttributesScript extends BaseGroovyScriptDaoImpl {
+
+    String keyToDuplicate;
+    Set<String> desiredNames;
+
+    AttributeDuplicatingPersonAttributesScript() {
+    }
+
+    public AttributeDuplicatingPersonAttributesScript(String keyToDuplicate, Set<String> desiredNames) {
+        this.keyToDuplicate = keyToDuplicate;
+        this.desiredNames = desiredNames;
+    }
+
+    @Override
+    Map<String, List<Object>> getPersonAttributesFromMultivaluedAttributes(Map<String, List<Object>> userAttributes) {
+        if (userAttributes?.get(keyToDuplicate)) {
+            List<Object> attributeValues = userAttributes.get(keyToDuplicate);
+            Map<String, List<Object>> newUserAttributes = new HashMap<> (userAttributes);
+            Iterator<String> i = desiredNames.iterator();
+            while (i.hasNext()) {
+                String desiredName = i.next();
+                newUserAttributes.put(desiredName, attributeValues);
+            }
+            return newUserAttributes
+        }
+        return null;
+    }
+
+    void setKeyToDuplicate(String keyToDuplicate) {
+        this.keyToDuplicate = keyToDuplicate
+    }
+
+    void setDesiredNames(Set<String> desiredNames) {
+        this.desiredNames = desiredNames
+    }
+}

--- a/uportal-war/src/main/resources/properties/contexts/personDirectoryContext.xml
+++ b/uportal-war/src/main/resources/properties/contexts/personDirectoryContext.xml
@@ -21,7 +21,7 @@
 -->
 
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns="http://www.springframework.org/schema/beans" 
+       xmlns="http://www.springframework.org/schema/beans"
        xmlns:aop="http://www.springframework.org/schema/aop"
        xmlns:util="http://www.springframework.org/schema/util"
        xmlns:p="http://www.springframework.org/schema/p"
@@ -199,6 +199,12 @@
                         *not* be given a chance to process the original query. But they will if you add
                         them directly to the MergingPersonAttributeDaoImpl.personAttributeDaos list here.)
                         -->
+                        <!-- Keep duplicateUsernameAttributeSource as the last DAO to duplicate the username
+                             if it wasn't already filled in by earlier sources.  This addresses UP-4177 for a person who has
+                             never logged into uPortal before and doesn't get their attributes set by LDAP
+                             or another source.
+                        -->
+                        <ref bean="duplicateUsernameAttributeSource"/>
                     </list>
                 </property>
             </bean>
@@ -230,13 +236,13 @@
             </map>
         </property>
     </bean>
-    
+
     <!--
      | Looks in the base UP_USER table, doesn't find attributes but will ensure a result if it the user exists in the
      | portal database and is searched for by username, results are cached by the outer caching DAO
      +-->
     <bean id="uPortalJdbcUserSource"
-        class="org.jasig.services.persondir.support.CachingPersonAttributeDaoImpl">
+          class="org.jasig.services.persondir.support.CachingPersonAttributeDaoImpl">
         <property name="usernameAttributeProvider" ref="usernameAttributeProvider" />
         <property name="cacheNullResults" value="true" />
         <property name="userInfoCache">
@@ -250,7 +256,7 @@
             <bean class="org.jasig.services.persondir.support.jdbc.SingleRowJdbcPersonAttributeDao">
                 <constructor-arg index="0" ref="PersonDB" />
                 <constructor-arg>
-                    <value> 
+                    <value>
                         SELECT USER_NAME
                         FROM UP_USER
                         WHERE {0}
@@ -276,7 +282,20 @@
             </bean>
         </property>
     </bean>
-    
+
+    <!--
+     | For any user coming into the system, new or existing, create uid and user.login.id attributes that match the
+     | username.
+     +-->
+    <bean id="duplicateUsernameAttributeScript" class="org.jasig.portal.persondir.AttributeDuplicatingPersonAttributesScript"
+          c:keyToDuplicate="username" c:desiredNames-ref="attributeNamesToDuplicateUsernameTo"/>
+    <bean id="duplicateUsernameAttributeSource" class="org.jasig.services.persondir.support.GroovyPersonAttributeDao"
+        c:groovyObject-ref="duplicateUsernameAttributeScript"/>
+    <util:set id="attributeNamesToDuplicateUsernameTo" value-type="java.lang.String">
+        <value>uid</value>
+        <value>user.login.id</value>
+    </util:set>
+
     <!-- Where non-local attribute DAOs go -->
     
     <bean id="userAttributeCacheKeyGenerator" class="org.jasig.portal.utils.cache.PersonDirectoryCacheKeyGenerator">

--- a/uportal-war/src/test/groovy/org.jasig.portal.persondir/AttributeDuplicatingPersonAttributesScriptTest.groovy
+++ b/uportal-war/src/test/groovy/org.jasig.portal.persondir/AttributeDuplicatingPersonAttributesScriptTest.groovy
@@ -1,0 +1,32 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import groovy.util.GroovyTestCase
+import org.jasig.portal.persondir.AttributeDuplicatingPersonAttributesScript
+import org.jasig.services.persondir.IPersonAttributeScriptDao
+
+class AttributeDuplicatingPersonAttributesScriptTest extends GroovyTestCase {
+    void testSomething() {
+        IPersonAttributeScriptDao dao = new AttributeDuplicatingPersonAttributesScript(
+                "username", new HashSet<String>(["uid", "user.login.id"]))
+        Map<String, List<Object>> userAttributes = dao.getPersonAttributesFromMultivaluedAttributes(
+                [username: ['tomThumb'].asList()])
+        assert userAttributes.size() == 3
+    }
+}


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4177

Upgrades to person-directory 1.6.0 to enable groovy-based scripts or classes in personDirectoryContext.  See https://github.com/Jasig/person-directory/blob/person-directory-parent-1.6.0/person-directory-impl/src/main/java/org/jasig/services/persondir/support/GroovyPersonAttributeDao.java#L38

Though could be done with PersonDirectory's StringFormatAttributeRule, this approach is MUCH GROOVIER!

Additional benefits to uPortal:
- uportal-war build process now support groovy classes AND Groovy unit test classes!!!
- can use groovy scripts in personDirectoryContext.xml (see link above)
