### PR TITLE
UP-4215 : Add quick deployment tasks

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -134,8 +134,8 @@
     <target name="deploy-less">
       <exec executable="lessc">
         <arg value="" />
-        <arg value="${basedir}/uportal-war/src/main/webapp/media/skins/bucky/defaultSkin.less" />
-        <arg value="${server.base}/webapps/portal/media/skins/bucky/defaultSkin.css" />
+        <arg value="${basedir}/uportal-war/src/main/webapp/media/skins/respondr/defaultSkin.less" />
+        <arg value="${server.base}/webapps/portal/media/skins/respondr/defaultSkin.css" />
       </exec>
     </target>
 


### PR DESCRIPTION
Added in the following ant targets:
- `deploy-less` - recompiles utilizing `lessc` and deploys it to tomcat
- `deploy-xsl` - deploys out everything under `/uportal-war/src/main/resources/layout` to tomcat

In doing this we will not need to do a `deploy-war`. Just think of all the compilation time we just saved.

![image](https://cloud.githubusercontent.com/assets/3534544/4015703/4462e7c0-2a2d-11e4-82d5-d31d7837ed95.png)
