### PR TITLE
UP-4177 When attribute to duplicate is missing, no-op.

### DIFF
--- a/uportal-war/src/main/groovy/org/jasig/portal/persondir/AttributeDuplicatingPersonAttributesScript.groovy
+++ b/uportal-war/src/main/groovy/org/jasig/portal/persondir/AttributeDuplicatingPersonAttributesScript.groovy
@@ -25,6 +25,9 @@ import org.jasig.services.persondir.support.BaseGroovyScriptDaoImpl
  * E.g. if an attribute called 'username' is present, add attributes uid and user.login.id if not present with the
  * list of values of the username attribute.
  *
+ * If the keyToDuplicate is not present, getPersonAttributesFromMultivaluedAttributes() returns the existing
+ * userAttributes unchanged as a no-op.
+ *
  * @author James Wennmacher, jwennmacher@unicon.net
  */
 
@@ -52,7 +55,7 @@ class AttributeDuplicatingPersonAttributesScript extends BaseGroovyScriptDaoImpl
             }
             return newUserAttributes
         }
-        return null;
+        return userAttributes;
     }
 
     void setKeyToDuplicate(String keyToDuplicate) {

--- a/uportal-war/src/test/groovy/org.jasig.portal.persondir/AttributeDuplicatingPersonAttributesScriptTest.groovy
+++ b/uportal-war/src/test/groovy/org.jasig.portal.persondir/AttributeDuplicatingPersonAttributesScriptTest.groovy
@@ -39,4 +39,22 @@ class AttributeDuplicatingPersonAttributesScriptTest extends GroovyTestCase {
           [username: ['tomThumb'].asList(), uid: ['tomThumb'].asList(), "user.login.id": ['tomThumb'].asList() ]
         assertEquals("username value should have duplicated to uid and user.login.id values.", expected, actual);
     }
+
+    /**
+     * Test that an AttributeDuplicatingPersonAttributesScript configured to duplicate the attitude attribute does
+     * not duplicate the attribute when presented with a user without that attribute.
+     */
+    void testNonMatchingUserAttributesDoNotDuplicate() {
+
+        IPersonAttributeScriptDao duplicator =
+                new AttributeDuplicatingPersonAttributesScript("attitude", new HashSet(["bearing", "demeanor"]));
+
+        Map expected = [username: ['gazda']]
+
+        Map actual = duplicator.getPersonAttributesFromMultivaluedAttributes(expected);
+
+        assertEquals "Duplicator should have been a no-op", expected , actual
+
+
+    }
 }


### PR DESCRIPTION
Make `AttributeDuplicatingPersonAttributesScript` that was introduced in #408 ([UP-4177](https://issues.jasig.org/browse/UP-4177)) no-op when the key-to-duplicate is not found.  Also refactor looping and enrichen unit test.
- Make the script return the existing attributes map un-changed when the key to duplicate is not present in the existing attributes map.
- Use idiomatic forEach in groovy ( `for (desiredName in desiredNames) {` )
- use `assertEquals` with message rather than bare Groovy `assert` keyword in unit test
- test the full content of the resulting attribute map against expected beyond just testing the resulting size.
