### PR TITLE
UP-4198 Added room for labels in Manage Portlets --> Portlet Preferences so text does not overlap

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/flows/edit-portlet/reviewPortlet.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/flows/edit-portlet/reviewPortlet.jsp
@@ -285,7 +285,7 @@ PORTLET DEVELOPMENT STANDARDS AND GUIDELINES
         <c:if test="${fn:length(cpd.steps) != 0}">
           <div class="tab-pane" id="parameters">
             <div class="form-group">
-              <div class="col-sm- col-sm-offset-3">
+              <div class="col-sm-2 col-sm-offset-3">
                 <a class="btn btn-default edit-action" href="${ setParametersUrl }"><span><spring:message code="edit.parameters"/></span></a>
               </div>
             </div>


### PR DESCRIPTION
Added room for labels so text does not overlap (https://issues.jasig.org/browse/UP-4198)
