### PR TITLE
[UP-4220] Clear the fluid_1_5 var after importing fluid so that subseque...

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -253,6 +253,7 @@
     up.fluid = fluid;
     fluid = null;
     fluid_1_4 = null;
+    fluid_1_5 = null;
     up._ = _.noConflict();
     up._.templateSettings = {
       interpolate : /{{=(.+?)}}/g,


### PR DESCRIPTION
...nt imports don't corrupt the reference.   This should fix an issue with the latest news portlet where adding the news portlet to the layout breaks the customize drawer.
