### PR TITLE
[UP-4245] exclude logback from the build during the hbm2ddl goal

### DIFF
--- a/uportal-portlets-overlay/CalendarPortlet/pom.xml
+++ b/uportal-portlets-overlay/CalendarPortlet/pom.xml
@@ -148,6 +148,19 @@
                                 <groupId>xalan</groupId>
                                 <artifactId>serializer</artifactId>
                             </exclusion>
+                            <!-- exclude logback during the build. -->
+                            <exclusion>
+                                <groupId>ch.qos.logback</groupId>
+                                <artifactId>logback-classic</artifactId>
+                            </exclusion>
+                            <exclusion>
+                                <groupId>ch.qos.logback</groupId>
+                                <artifactId>logback-core</artifactId>
+                            </exclusion>
+                            <exclusion>
+                                <groupId>org.slf4j</groupId>
+                                <artifactId>log4j-over-slf4j</artifactId>
+                            </exclusion>
                         </exclusions>
                     </dependency>
                 </dependencies>


### PR DESCRIPTION
Calendar portlet is the first portlet to both do db-init and use a logback.xml file.   Unfortunately, the version of the hibernate plugin blows up with that combination.  I could not quickly find a way to pass a system property to the configuration to force it to use the command-line.logback.xml file.   So, for now, just exclude logback from that plugins dependencies.   It still outputs to the console, but no longer fails my build.
