### PR TITLE
[UP-4130] Fix the google analytics UI.  A previous fix fixed the backbon...

### DIFF
--- a/uportal-war/src/main/webapp/WEB-INF/jsp/GoogleAnalytics/config.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/GoogleAnalytics/config.jsp
@@ -170,8 +170,6 @@ up.analytics.config.view = up.analytics.config.view || {};
       },
 
       initialize : function() {
-         _.bindAll(this);
-
          this.listenTo(this.model, 'change', this.render);
          this.listenTo(this.model, 'destroy', this.remove);
       },
@@ -315,8 +313,6 @@ up.analytics.config.view = up.analytics.config.view || {};
       el : $("div#${n}google-analytics-config"),
 
       initialize : function() {
-         _.bindAll(this);
-
          this.listenTo(this.model, 'change', this.render);
          this.listenTo(this.model.get("hosts"), 'add', this.render);
          this.listenTo(this.model.get("hosts"), 'remove', this.render);


### PR DESCRIPTION
...e dep.  Here, I just had to remove the bindAll calls.  As best I can tell, that call was unnecessary and not supported in latest versions of underscore anyhow (at least this version of that call is no longer supported).

https://issues.jasig.org/browse/UP-4130
