### PR TITLE
UP-4262 : toString() in DynamicRenderingPipeline.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/rendering/DynamicRenderingPipeline.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/DynamicRenderingPipeline.java
@@ -119,4 +119,11 @@ public class DynamicRenderingPipeline implements IPortalRenderingPipeline {
         this.logger.warn("No mediaType was specified in the pipeline output properties, defaulting to " + DEFAULT_MEDIA_TYPE);
         return DEFAULT_MEDIA_TYPE;
     }
+
+    @Override
+    public String toString() {
+        return "DynamicRenderingPipeline using url syntax provider [" + this.urlSyntaxProvider +
+                "] and wrapping pipeline component [" + this.pipeline +
+                "].";
+    }
 }

--- a/uportal-war/src/test/java/org/jasig/portal/rendering/DynamicRenderingPipelineTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/rendering/DynamicRenderingPipelineTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portal.rendering;
+
+import org.jasig.portal.url.IUrlSyntaxProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Unit tests for DynamicRenderingPipeline.
+ */
+public class DynamicRenderingPipelineTest {
+
+    @Mock IUrlSyntaxProvider urlSyntaxProvider;
+
+    @Mock CharacterPipelineComponent characterPipelineComponent;
+
+    @Before
+    public void beforeTests() {
+        initMocks(this);
+    }
+
+    /**
+     * Test that DynamicRenderingPipeline has a friendly toString() implementation.
+     */
+    @Test
+    public void hasFriendlyToString() {
+
+        when(urlSyntaxProvider.toString()).thenReturn("String representing urlSyntaxProvider.");
+        when(characterPipelineComponent.toString()).thenReturn("String representing characterPipelineComponent.");
+
+        final DynamicRenderingPipeline dynamicRenderingPipeline = new DynamicRenderingPipeline();
+        dynamicRenderingPipeline.setUrlSyntaxProvider(urlSyntaxProvider);
+        dynamicRenderingPipeline.setPipeline(characterPipelineComponent);
+
+        final String friendlyToString = "DynamicRenderingPipeline using url syntax provider " +
+                "[String representing urlSyntaxProvider.] and wrapping pipeline component " +
+                "[String representing characterPipelineComponent.].";
+
+        assertEquals(friendlyToString, dynamicRenderingPipeline.toString());
+    }
+}


### PR DESCRIPTION
Trivial: adds a `toString()` implementation in `DynamicRenderingPipeline` as a step towards enabling better logging.

It's a small step, since the objects included in the `String` do not themselves have friendly `toString()`.  Small steps.

This is in the context of [MyUW's customizations to the rendering pipeline](http://apetro.ghost.io/pipelines-need-valves/), where logging the chosen branch out of a `BranchingRenderingPipeline` is handy.

See also tracking JIRA [UP-4262](https://issues.jasig.org/browse/UP-4262).
