### PR TITLE
UP-4261 : Add FocusedOnOnePortletPredicate

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/FocusedOnOnePortletPredicate.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/predicates/FocusedOnOnePortletPredicate.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.jasig.portal.rendering.predicates;
 
 import com.google.common.base.Predicate;

--- a/uportal-war/src/test/java/org/jasig/portal/rendering/predicates/FocusedOnOnePortletPredicateTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/rendering/predicates/FocusedOnOnePortletPredicateTest.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.jasig.portal.rendering.predicates;
 
 import org.jasig.portal.url.IPortalRequestInfo;


### PR DESCRIPTION
Add `FocusedOnOnePortletPredicate` which answers whether a given `HttpServletRequest` addresses a particular portlet (i.e., maximized, exclusive, detached) or not.

See JIRA [UP-4261](https://issues.jasig.org/browse/UP-4261) and [context on how MyUW is using this Predicate](http://apetro.ghost.io/pipelines-need-valves/) to condition branching the rendering pipeline.

Intended to be useful in plugging in as the `Predicate` to a `BranchingRenderingPipeline`.
## Logging

Logs how it made its decision at `DEBUG`, useful for development and troubleshooting.

```
DEBUG o.j.p.r.p.FocusedOnOnePortletPredicate  - Determined request with UrlState MAX does focus on one portlet.
...
DEBUG o.j.p.r.p.FocusedOnOnePortletPredicate - Determined request with UrlState NORMAL does not focus on one portlet.
```
## Example usage

MyUW's customized `renderingPipelineContext.xml` uses this `Predicate` like this:

```
<!-- this branching valve takes the `id` of the out-of-the-box `portalRenderingPipeline` and wraps that default `DynamicRenderingPipeline` as the `false` branch. -->
<bean id="portalRenderingPipeline" class="org.jasig.portal.rendering.BranchingRenderingPipeline">
        <qualifier value="main" />
        <property name="predicate">
            <!-- If using Bucky AND NOT focused on one portlet, redirect to /web. (true path)
                 otherwise proceed down regular dynamic rendering pipeline (false path). -->
            <bean class="com.google.common.base.Predicates" factory-method="and">
                <constructor-arg>
                    <list>
                        <bean class="org.jasig.portal.rendering.predicates.ProfileFNamePredicate">
                            <property name="profileFNameToMatch" value="${angular.profile.name}" />
                        </bean>
                        <ref bean="notFocusedOnOnePortletPredicate" />
                    </list>
                </constructor-arg>
            </bean>
        </property>
        <property name="truePipe" ref="redirectToWeb" />
        <property name="falsePipe" ref="dynamicRenderingPipeline" />
    </bean>


    <bean id="notFocusedOnOnePortletPredicate"
          class="com.google.common.base.Predicates" factory-method="not">
        <constructor-arg>
            <bean class="org.jasig.portal.rendering.predicates.FocusedOnOnePortletPredicate" />
        </constructor-arg>
    </bean>
```
