### PR TITLE
UP-4263 : Add RedirectRenderingPipelineTerminator

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/rendering/RedirectRenderingPipelineTerminator.java
+++ b/uportal-war/src/main/java/org/jasig/portal/rendering/RedirectRenderingPipelineTerminator.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.jasig.portal.rendering;
 
 import org.slf4j.Logger;

--- a/uportal-war/src/test/java/org/jasig/portal/rendering/RedirectRenderingPipelineTerminatorTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/rendering/RedirectRenderingPipelineTerminatorTest.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.jasig.portal.rendering;
 
 import org.junit.Before;


### PR DESCRIPTION
Add a `RedirectRenderingPipelineTerminator` `IPortalRenderingPipeline` implementation that simply redirects to a configured path, terminating the rendering pipeline.

See JIRA [UP-4263](https://issues.jasig.org/browse/UP-4263) and [context on MyUW's conditionally terminating the rendering pipeline in a redirect](http://apetro.ghost.io/pipelines-need-valves/).
## Logging

Logs at `TRACE` useful for development and troubleshooting.

```
TRACE o.j.p.r.BranchingRenderingPipeline - Branching to the true pipe [RedirectRenderingPipelineTerminator which redirects to /web .].
```
## Configuration example

Here's how MyUW is conditionally using this terminator.

```
<!-- This valve takes the place of the out of the box beginning of the pipeline, wrapping that ootb pipeline as one of the downstream branches, and redirecting as the other branch, depending upon a Predicate. -->
  <bean id="portalRenderingPipeline" class="org.jasig.portal.rendering.BranchingRenderingPipeline">
        <qualifier value="main" />
        <property name="predicate">
            ...
        </property>
        <property name="truePipe" ref="redirectToWeb" />
        <property name="falsePipe" ref="dynamicRenderingPipeline" />
    </bean>

    <bean id="redirectToWeb" class="org.jasig.portal.rendering.RedirectRenderingPipelineTerminator">
        <property name="redirectTo" value="${angular.landing.page}" />
    </bean>
```
