### PR TITLE
UP-4264 Reset cache control on portlet resource request if not using cached response

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlet/container/cache/CacheControlImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/container/cache/CacheControlImpl.java
@@ -20,6 +20,7 @@
 package org.jasig.portal.portlet.container.cache;
 
 import javax.portlet.CacheControl;
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -34,7 +35,18 @@ public class CacheControlImpl implements CacheControl {
     // PLT.22.1 cache scope is assumed private by default
     private boolean publicScope = false;
     private boolean useCachedContent = false;
-    
+
+    /**
+     * Reset the cache control settings to their default values.
+     * @param httpServletRequest HttpServletRequest
+     */
+    public void resetProperties(HttpServletRequest httpServletRequest) {
+        setETag(httpServletRequest.getHeader("If-None-Match"));
+        setPublicScope(false);
+        setUseCachedContent(false);
+        setExpirationTime(0);
+    }
+
 	/* (non-Javadoc)
      * @see javax.portlet.CacheControl#getETag()
      */

--- a/uportal-war/src/main/java/org/jasig/portal/portlet/rendering/PortletRendererImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/rendering/PortletRendererImpl.java
@@ -60,7 +60,6 @@ import org.jasig.portal.security.IPerson;
 import org.jasig.portal.security.IPersonManager;
 import org.jasig.portal.services.AuthorizationService;
 import org.jasig.portal.url.IPortalRequestInfo;
-import org.jasig.portal.url.IPortletUrlBuilder;
 import org.jasig.portal.url.IUrlSyntaxProvider;
 import org.jasig.portal.url.ParameterMap;
 import org.jasig.portal.utils.web.PortletHttpServletRequestWrapper;
@@ -554,9 +553,18 @@ public class PortletRendererImpl implements IPortletRenderer {
         final CachingPortletResourceOutputHandler cachingPortletOutputHandler = new CachingPortletResourceOutputHandler(portletOutputHandler, cacheSizeThreshold);
 
         CacheControl cacheControl = cacheState.getCacheControl();
+
+        // UP-4264 We are about to invoke the portlet, so reset the eTag and other cacheControl properties to the
+        // default values per the portlet spec, not the previous potentially cached values. In particular we don't
+        // want the cached eTag value if the browser did not send an eTag, but also the portlet will be expecting
+        // the cache control properties to be at the default values (in case it sets them differently for some reason).
+        if (cacheControl instanceof CacheControlImpl) {
+            ((CacheControlImpl)cacheControl).resetProperties(httpServletRequest);
+        }
+
         //Wrap the cache control so it immediately sets the caching related response headers
         cacheControl = new HeaderSettingCacheControl(cacheControl, cachingPortletOutputHandler);
-        
+
         //Setup the request and response
         httpServletRequest = this.setupPortletRequest(httpServletRequest);
         httpServletResponse = new PortletResourceHttpServletResponseWrapper(httpServletResponse, portletWindow, portletOutputHandler, cacheControl);


### PR DESCRIPTION
Fixes problem of uPortal sending eTag to portlet that browser did not send, plus properly resetting properties to default values per portlet spec.
