### PR TITLE
[UP-4095 / UP-4103] Move footer content out of the XSL to a JSP.

### DIFF
--- a/uportal-war/src/main/data/default_entities/portlet-definition/legal-footer.portlet-definition.xml
+++ b/uportal-war/src/main/data/default_entities/portlet-definition/legal-footer.portlet-definition.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+  ~ Licensed to Jasig under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work
+  ~ for additional information regarding copyright ownership.
+  ~ Jasig licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file
+  ~ except in compliance with the License. You may obtain a
+  ~ copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on
+  ~ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<portlet-definition version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/permission-owner" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/portlet-type">
+    <title>Legal Footer</title>
+    <name>Legal Footer</name>
+    <fname>legal-footer</fname>
+    <desc>Legal links for uPortal</desc>
+    <type>Portlet</type>
+    <timeout>5000</timeout>
+    <portlet-descriptor>
+        <ns2:isFramework>true</ns2:isFramework>
+        <ns2:portletName>JspInvoker</ns2:portletName>
+    </portlet-descriptor>
+    <group>Everyone</group>
+    <parameter>
+        <name>disableDynamicTitle</name>
+        <value>true</value>
+    </parameter>
+    <portlet-preference>
+        <name>JspInvokerPortletController.viewLocation</name>
+        <readOnly>false</readOnly>
+        <value>/jsp/Invoker/legalFooter</value>
+    </portlet-preference>
+</portlet-definition>

--- a/uportal-war/src/main/data/quickstart_entities/fragment-layout/all-lo.fragment-layout.xml
+++ b/uportal-war/src/main/data/quickstart_entities/fragment-layout/all-lo.fragment-layout.xml
@@ -28,25 +28,28 @@
      | have their own copies of the minimal portlets required to view and manage
      | their own layouts.
      +-->
-    <folder ID="s2" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
-      <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n3"/>
-      <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n4"/>
+    <folder ID="s100" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+      <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n110"/>
+      <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n120"/>
     </folder>
-    <folder ID="s5" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
-      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n6"/>
+    <folder ID="s200" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n210"/>
     </folder>
-    <folder ID="s7" hidden="false" immutable="true" name="Header Bottom folder" type="header-bottom" unremovable="true">
-      <channel fname="emergency-alert" unremovable="false" hidden="false" immutable="false" ID="n8"/>
+    <folder ID="s300" hidden="false" immutable="true" name="Header Bottom folder" type="header-bottom" unremovable="true">
+      <channel fname="emergency-alert" unremovable="false" hidden="false" immutable="false" ID="n310"/>
     </folder>
-    <folder ID="s9" hidden="false" immutable="true" name="Customize folder" type="customize" unremovable="true">
-      <channel fname="background-preference" unremovable="true" hidden="false" immutable="false" ID="n10"/>
+    <folder ID="s400" hidden="false" immutable="true" name="Customize folder" type="customize" unremovable="true">
+      <channel fname="background-preference" unremovable="true" hidden="false" immutable="false" ID="n410"/>
     </folder>
-    <folder ID="s11" hidden="false" immutable="true" name="Pre Content folder" type="pre-content" unremovable="true">
-      <channel fname="tips" unremovable="false" hidden="false" immutable="false" ID="n12"/>
+    <folder ID="s500" hidden="false" immutable="true" name="Pre Content folder" type="pre-content" unremovable="true">
+      <channel fname="tips" unremovable="false" hidden="false" immutable="false" ID="n510"/>
     </folder>
-    <folder ID="s13" hidden="false" immutable="true" name="Page Bottom folder" type="page-bottom" unremovable="true">
-      <channel fname="attachments" unremovable="true" hidden="false" immutable="false" ID="n14"/>
-      <channel fname="google-analytics-config" unremovable="true" hidden="false" immutable="false" ID="n15"/>
+    <folder id="s600" hidden="false" immutable="true" name="Legal Footer" type="footer-second" unremovable="true">
+        <channel fname="legal-footer" unremovable="true" hidden="false" immutable="false" ID="n610"/>
+    </folder>
+    <folder ID="s700" hidden="false" immutable="true" name="Page Bottom folder" type="page-bottom" unremovable="true">
+      <channel fname="attachments" unremovable="true" hidden="false" immutable="false" ID="n710"/>
+      <channel fname="google-analytics-config" unremovable="true" hidden="false" immutable="false" ID="n720"/>
     </folder>
   </folder>
 </layout>

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -358,24 +358,16 @@
 <!-- 
  | YELLOW
  | This template renders the tabs at the top of the page.
+ | TODO:  Move footer.nav to footer.first and convert to a portlet (see UP-4103)
  -->
-<xsl:template name="footer.legal">
-    <footer class="portal-footer-legal" role="contentinfo">
-        <div class="container-fluid">
-            <div class="portal-power">
-                <h2><a href="http://www.jasig.org/uportal" target="_blank">Powered by uPortal</a>, an open-source project by <a href="http://www.jasig.org" title="Jasig.org - Open for Higher Education">Jasig</a></h2>
-                <ul>
-                    <li><a href="http://www.jasig.org/" target="_blank">Jasig.org</a></li>
-                    <li><a href="http://www.jasig.org/uportal" target="_blank">uPortal.org</a></li>
-                    <li><a href="http://www.jasig.org/uportal/download" target="_blank">Download</a></li>
-                    <li><a href="http://www.jasig.org/uportal/community" target="_blank">Community</a></li>
-                    <li><a href="http://www.opentracker.net/article/how-write-website-privacy-policy" target="_blank">Privacy Policy</a></li>
-                    <li><a href="http://wiki.jasig.org/display/UPM40/Accessibility" target="_blank">Accessibility</a></li>
-                </ul>
-                <p><a href="http://www.jasig.org/uportal/about/license" title="uPortal" target="_blank">uPortal</a> is licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0" title="Apache License, Version 2.0" target="_blank">Apache License, Version 2.0</a> as approved by the Open Source Initiative (OSI), an <a href="http://www.opensource.org/docs/osd" title="OSI-certified" target="_blank">OSI-certified</a> ("open") and <a href="http://www.gnu.org/licenses/license-list.html" title="Gnu/FSF-recognized" target="_blank">Gnu/FSF-recognized</a> ("free") license.</p>
-            </div>
-        </div>
-    </footer>
+<xsl:template name="footer.second">
+    <xsl:if test="//region[@name='footer-second']/channel">
+        <footer class="portal-footer-legal" role="contentinfo">
+            <xsl:for-each select="//region[@name='footer-second']/channel">
+                <xsl:call-template name="regions.portlet.decorator" />
+            </xsl:for-each>
+        </footer>
+    </xsl:if>
 </xsl:template>
 <!-- ========================================================================= -->
 
@@ -740,7 +732,7 @@
                 </div>
                 <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->
                 <xsl:call-template name="footer.nav" />
-                <xsl:call-template name="footer.legal" />
+                <xsl:call-template name="footer.second" />
                 <xsl:call-template name="region.page-bottom" />
                 <xsl:call-template name="region.hidden-bottom" />
                 <chunk-point/> <!-- Performance Optimization, see ChunkPointPlaceholderEventSource -->

--- a/uportal-war/src/main/webapp/WEB-INF/jsp/Invoker/legalFooter.jsp
+++ b/uportal-war/src/main/webapp/WEB-INF/jsp/Invoker/legalFooter.jsp
@@ -1,0 +1,36 @@
+<%--
+  ~ Licensed to Jasig under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work
+  ~ for additional information regarding copyright ownership.
+  ~ Jasig licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file
+  ~ except in compliance with the License. You may obtain a
+  ~ copy of the License at:
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on
+  ~ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  --%>
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+
+<%@ include file="/WEB-INF/jsp/include.jsp" %>
+
+<div class="container-fluid">
+    <div class="portal-power">
+        <h2><a href="http://www.jasig.org/uportal" target="_blank">Powered by uPortal</a>, an open-source project by <a href="http://www.jasig.org" title="Jasig.org - Open for Higher Education">Jasig</a> - ${pageContext.request.serverName}</h2>
+        <ul>
+            <li><a href="http://www.jasig.org/" target="_blank">Jasig.org</a></li>
+            <li><a href="http://www.jasig.org/uportal" target="_blank">uPortal.org</a></li>
+            <li><a href="http://www.jasig.org/uportal/download" target="_blank">Download</a></li>
+            <li><a href="http://www.jasig.org/uportal/community" target="_blank">Community</a></li>
+            <li><a href="http://www.opentracker.net/article/how-write-website-privacy-policy" target="_blank">Privacy Policy</a></li>
+            <li><a href="http://wiki.jasig.org/display/UPM40/Accessibility" target="_blank">Accessibility</a></li>
+        </ul>
+        <p><a href="http://www.jasig.org/uportal/about/license" title="uPortal" target="_blank">uPortal</a> is licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0" title="Apache License, Version 2.0" target="_blank">Apache License, Version 2.0</a> as approved by the Open Source Initiative (OSI), an <a href="http://www.opensource.org/docs/osd" title="OSI-certified" target="_blank">OSI-certified</a> ("open") and <a href="http://www.gnu.org/licenses/license-list.html" title="Gnu/FSF-recognized" target="_blank">Gnu/FSF-recognized</a> ("free") license.</p>
+    </div>
+</div>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4095

partially addresses:

https://issues.jasig.org/browse/UP-4103   (still need to convert footer navigation to a portlet.  Related to https://issues.jasig.org/browse/UP-3969)
