### PR TITLE
[UP-4275] Add documentation to help distinguish between name/title.  Fix...

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortletDefinitionImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/dao/jpa/PortletDefinitionImpl.java
@@ -117,7 +117,12 @@ class PortletDefinitionImpl implements IPortletDefinition {
     @JoinColumn(name = "PORTLET_PREFS_ID", nullable = false)
     @Fetch(FetchMode.JOIN)
     private final PortletPreferencesImpl portletPreferences;
-    
+
+    /**
+     * Name is used for admin tools, but will typically not be presented to end users.  It allows
+     * for situations where you need to define multiple similar portlets, all sharing a title. but
+     * still provides a way to distinguish between the portlets in admin tools.
+     */
     @Column(name = "PORTLET_NAME", length = 128, nullable = false, unique = true)
     private String name;
 
@@ -125,7 +130,7 @@ class PortletDefinitionImpl implements IPortletDefinition {
 	@Column(name = "PORTLET_FNAME", length = 255, nullable = false)
 	@Type(type = "fname")
 	private String fname;
-	
+
     @Column(name = "PORTLET_TITLE", length = 128, nullable = false)
     @Index(name = "IDX_PORTLET_DEF__TITLE")
     private String title;

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -336,7 +336,7 @@
                                                     </xsl:with-param>
                                                 </xsl:call-template>
                                             </xsl:variable>
-                                            <li><a href="{$portletLinkUrl}"><xsl:value-of select="@name" /></a></li>
+                                            <li><a href="{$portletLinkUrl}"><xsl:value-of select="@title" /></a></li>
                                         </xsl:for-each>
                                     </ul>
                                 </div>

--- a/uportal-war/src/main/resources/xsd/io/portlet-definition/portlet-definition-4.0.xsd
+++ b/uportal-war/src/main/resources/xsd/io/portlet-definition/portlet-definition-4.0.xsd
@@ -38,6 +38,9 @@
                 <xs:extension base="io:basePortalDataType40">
                     <xs:sequence>
                         <xs:element name="title" type="xs:string"/>
+                        <!-- 'title' is the value that will be displayed in the portlet chrome and in
+                            navigation menus.  'name' is intended primarily for internal or admin usage.
+                            'name' can be used to distinguish between similar portlets that may share a title. -->
                         <xs:element name="name" type="xs:string"/>
                         <xs:element name="fname" type="up:fname-type"/>
                         <xs:element name="desc" type="xs:string" minOccurs="0"/>

--- a/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-gallery.js
+++ b/uportal-war/src/main/webapp/media/skins/common/javascript/uportal/up-layout-gallery.js
@@ -175,6 +175,12 @@ var up = up || {};
                                                 data: row
                                             };
                                         }
+                                    },
+                                    {
+                                        type: 'attrs',
+                                        attributes: {
+                                            title: row.title + ' (' + row.name + ')'
+                                        }
                                     }
                                 ]
                             };


### PR DESCRIPTION
...ed title in site map link so it is consistent.   Add tooltip to the customize gallery to display 'name' and 'fname'.

https://issues.jasig.org/browse/UP-4275

This is just a stop-gap that fixes 1 real issue (sitemap uses name instead of title), 1 small tweak (add tooltip w/ name in customize) and a few comments.   The real fix should be done as part of https://issues.jasig.org/browse/UP-4283
