### PR TITLE
UP-4223 Fail gracefully in handling profile selection events.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/profile/StickyProfileMapperImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/profile/StickyProfileMapperImpl.java
@@ -91,37 +91,43 @@ public class StickyProfileMapperImpl
     @Override
     public void onApplicationEvent(ProfileSelectionEvent event) {
 
-        final String userName = event.getPerson().getUserName();
+        try {
 
-        if (identitySwapperManager.isImpersonating(event.getRequest())) {
-            logger.debug("Ignoring selection of profile by key {} in the context of user {} because impersonated.",
-                    event.getRequestedProfileKey(), userName );
-            return;
+            final String userName = event.getPerson().getUserName();
+
+            if (identitySwapperManager.isImpersonating(event.getRequest())) {
+                logger.debug("Ignoring selection of profile by key {} in the context of user {} because impersonated.",
+                        event.getRequestedProfileKey(), userName);
+                return;
+            }
+
+            if (profileKeyForNoSelection != null
+                    && profileKeyForNoSelection.equals(event.getRequestedProfileKey())) {
+
+                logger.trace("Translating {} selection of profile key {} to apathy about profile selection.",
+                        userName, event.getRequestedProfileKey());
+                profileSelectionRegistry.registerUserProfileSelection(userName, null);
+
+                return;
+
+            }
+
+            if (!immutableMappings.containsKey(event.getRequestedProfileKey())) {
+                logger.warn("User desired a profile by a key {} that does not map to any profile fname.  Ignoring.",
+                        event.getRequestedProfileKey());
+                return;
+            }
+
+
+            final String profileFName = immutableMappings.get(event.getRequestedProfileKey());
+
+            logger.trace("Storing {} selection of profile fname {} (keyed by profile key {})",
+                    userName, profileFName, event.getRequestedProfileKey());
+            profileSelectionRegistry.registerUserProfileSelection(userName, profileFName);
+
+        } catch (final Exception e) {
+            logger.error("Something went wrong handling profile selection event " + event);
         }
-
-        if (profileKeyForNoSelection != null
-                && profileKeyForNoSelection.equals(event.getRequestedProfileKey())) {
-
-            logger.trace("Translating {} selection of profile key {} to apathy about profile selection.",
-                    userName, event.getRequestedProfileKey());
-            profileSelectionRegistry.registerUserProfileSelection(userName, null);
-
-            return;
-
-        }
-
-        if (!immutableMappings.containsKey(event.getRequestedProfileKey())) {
-            logger.warn("User desired a profile by a key {} that does not map to any profile fname.  Ignoring.",
-                    event.getRequestedProfileKey());
-            return;
-        }
-
-
-        final String profileFName = immutableMappings.get(event.getRequestedProfileKey());
-
-        logger.trace("Storing {} selection of profile fname {} (keyed by profile key {})",
-                userName, profileFName, event.getRequestedProfileKey());
-        profileSelectionRegistry.registerUserProfileSelection(userName, profileFName);
     }
 
     @Override

--- a/uportal-war/src/test/java/org/jasig/portal/layout/profile/StickyProfileMapperImplTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/layout/profile/StickyProfileMapperImplTest.java
@@ -99,6 +99,22 @@ public class StickyProfileMapperImplTest {
     }
 
     /**
+     * Test that when the underlying registry throws in the course of handling profile selection event,
+     * failure does not propagate out of the event handling method.
+     */
+    @Test
+    public void testFailsEventHandlingGracefully() {
+
+        doThrow(RuntimeException.class).when(registry).registerUserProfileSelection("bobby", "profileFName1");
+
+        final ProfileSelectionEvent selectionEvent = new ProfileSelectionEvent(this, "validKey1", person, request);
+
+        stickyMapper.onApplicationEvent(selectionEvent);
+
+        verify(registry).registerUserProfileSelection("bobby", "profileFName1");
+    }
+
+    /**
      * Test that when the identity is swapped, ignores profile selection requests.
      */
     @Test


### PR DESCRIPTION
This is a tweak to merged #450 to make handling the `ProfileSelectionEvent` safe.

Failure to persist a profile selection is bad (and is an error, and should be logged so that the portal administrators can address it.)  But failing to persist a profile selection shouldn't fail the entire portal experience for the user.
