### PR TITLE
UP-4223 Sticky profile mapping fails gracefully.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/profile/StickyProfileMapperImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/profile/StickyProfileMapperImpl.java
@@ -53,6 +53,9 @@ import java.util.Map;
  *
  * Subsequent or upstream profile mappers can fall back on a default, see also ChainingProfileMapperImpl.
  *
+ * Fails gracefully.  If persisted profile selection if any cannot be determined, logs and returns null indicating no
+ * available opinion about desired profile mapping.
+ *
  * Typically this mapper will be in the profile mapping chain within a ChainingProfileMapperImpl.
  *
  * @since uPortal 4.2
@@ -133,8 +136,13 @@ public class StickyProfileMapperImpl
         final String userName = person.getUserName();
         Validate.notNull(userName, "Cannot get profile fname for a null username.");
 
-        return this.profileSelectionRegistry.profileSelectionForUser(userName);
+        try {
+            return this.profileSelectionRegistry.profileSelectionForUser(userName);
+        } catch (Exception e) {
+            logger.error("Failed to read persisted profile selection for user " + userName + " if any.  Ignoring.", e);
+        }
 
+        return null; // default to no opinion if registry lookup failed.
     }
 
 

--- a/uportal-war/src/test/java/org/jasig/portal/layout/profile/StickyProfileMapperImplTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/layout/profile/StickyProfileMapperImplTest.java
@@ -68,7 +68,7 @@ public class StickyProfileMapperImplTest {
     }
 
     /**
-     * Test that when the underlying service has a stored selection for a user, reflects that selection.
+     * Test that when the underlying registry has a stored selection for a user, reflects that selection.
      */
     @Test
     public void testReflectsStoredSelection() {
@@ -76,6 +76,33 @@ public class StickyProfileMapperImplTest {
         final String mappedFName = stickyMapper.getProfileFname(person, request);
 
         assertEquals("profileFNameFromRegistry", mappedFName);
+
+    }
+
+    /**
+     * Test that when the underlying registry has no stored selection for a user,
+     * maps to null (indicating no opinion about what profile ought to be mapped.)
+     */
+    @Test
+    public void testMapsToNullWhenNoStoredSelection() {
+
+        // over-ride the set-up specified behavior
+        when(registry.profileSelectionForUser("bobby")).thenReturn(null);
+
+        assertNull(stickyMapper.getProfileFname(person, request));
+    }
+
+    /**
+     * Test that when the underlying registry fails, translates this failure into a null mapping
+     * (indicating no available opinion about what profile ought to be mapped.)
+     */
+    @Test
+    public void testMapsToNullWhenUnderlyingRegistryThrows() {
+
+        // over-ride the set-up specified behavior
+        when(registry.profileSelectionForUser("bobby")).thenThrow(RuntimeException.class);
+
+        assertNull(stickyMapper.getProfileFname(person, request));
 
     }
 


### PR DESCRIPTION
This is a tweak to #450 on the same theme as #454 .

Failing to honor a persisted profile selection is bad.  It's an error and should be logged for portal administrators to address.  However, it's probably better to press on falling back on some default profile selection instead of failing the entire user experience on account of uncertainty about whether a sticky profile selection has been applied.  So, fail gracefully on registry failure, as if user had no sticky profile selection.
