### PR TITLE
UP-4285 Fail gracefully in ChainingProfileMapper.

### DIFF
--- a/uportal-war/src/test/java/org/jasig/portal/layout/profile/ChainingProfileMapperImplTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/layout/profile/ChainingProfileMapperImplTest.java
@@ -85,4 +85,26 @@ public class ChainingProfileMapperImplTest {
         assertEquals("profile2", fname);
     }
 
+    /**
+     * Fails gracefully when one mapper fails, proceeding to the next mapper.
+     */
+    @Test
+    public void testFailsGracefullyProceedingToNextMapper() {
+        when(subMapper1.getProfileFname(person, request)).thenThrow(RuntimeException.class);
+        when(subMapper2.getProfileFname(person, request)).thenReturn("profile2");
+        String fname = mapper.getProfileFname(person, request);
+        assertEquals("profile2", fname);
+    }
+
+    /**
+     * Fails gracefully when the last mapper throws, falling back on the default.
+     */
+    @Test
+    public void testFailsGracefullyToDefaultWhenLastMapperThrows() {
+        when(subMapper2.getProfileFname(person, request)).thenThrow(RuntimeException.class);
+        String fname = mapper.getProfileFname(person, request);
+        // "profile" is the default profile name configured in setUp().
+        assertEquals("profile", fname);
+    }
+
 }


### PR DESCRIPTION
Treat throwing sub-mappers as if had returned null (had no opinion about profile mapping), logging the error.

Failing to select the very best profile for a given user session is bad, but the thing to do under the circumstances is to note the problem and try to do the best mapping that can be had.  This means proceeding down the chain if a mapper in the chain is broken, and falling back on the default if no mappers are working.

I initially coded this as a default but optional behavior, with a `failsGracefully` property and an ability to set that to `false` so that it would propagate the failures of mappers.  But then I had trouble imagining an adopter actually wanting to escalate a profile mapping failure into a complete failure of the portal for a user.  YAGNI.  So here's the changeset just embracing failing gracefully.  If uPortal really needs the configuration complexity to make this optional, trivial to code and willing to do it.

[UP-4285](https://issues.jasig.org/browse/UP-4285).
