### PR TITLE
UP-4288 Link Manual from quick start readme.

### DIFF
--- a/assembly/quickstart/README.txt
+++ b/assembly/quickstart/README.txt
@@ -88,7 +88,12 @@ Notes
 - Log messages for uPortal appear in @tomcat.name@/logs/uPortal.log .
 - Log files for Tomcat appear in @tomcat.name@/logs
 
+Documentation
+--------------------------------------------------------------------------------
 
+The uPortal product manual is maintained as an online wiki at
+
+ https://wiki.jasig.org/display/UPM41/Home
 
 
 Contact


### PR DESCRIPTION
Trivial.  Adds the URL of the uPortal 4.1 manual to the README.txt that's included in the Quickstart.
