### PR TITLE
UP-4223 Transactionalize registerUserProfileSelection()

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/profile/ProfileSelectionRegistry.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/profile/ProfileSelectionRegistry.java
@@ -18,6 +18,7 @@
  */
 package org.jasig.portal.layout.profile;
 
+import org.jasig.portal.jpa.BasePortalJpaDao;
 import org.jasig.portal.layout.profile.dao.IProfileSelectionDao;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
@@ -50,6 +51,7 @@ public class ProfileSelectionRegistry
     }
 
     @Override
+    @BasePortalJpaDao.PortalTransactional
     public void registerUserProfileSelection(final String userName, final String profileFName) {
 
         Assert.notNull(userName, "Cannot register a profile selection for a null username.");


### PR DESCRIPTION
This is a tweak to #450 to apply a transaction aspect on a `ProfileSelectionRegistry` method that wraps multiple profile selection DAO methods, so that those methods are wrapped into a single transaction.

There's some ghost :ghost: in the machine when testing against an Oracle (rather than hsql) RBDMS such that profile selection updates intermittently fail with a unique constraint violation.  :grimacing:  Hoping that it turns out to be this transactionality bug and that applying this aspect makes that ghost go away. 
