### PR TITLE
UP-4287 Switch groovy compilation to GMavenPlus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -730,6 +730,12 @@
                 <artifactId>groovy-xml</artifactId>
                 <version>${groovy.version}</version>
             </dependency>
+            <!-- for GMavenPlus compilation -->
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${groovy.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.codehaus.staxmate</groupId>
                 <artifactId>staxmate</artifactId>

--- a/uportal-war/pom.xml
+++ b/uportal-war/pom.xml
@@ -760,43 +760,20 @@
         <plugins>
             <!-- Compile groovy classes -->
             <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.2</version>
                 <executions>
                     <execution>
-                        <id>compile</id>
-                        <phase>generate-sources</phase>
-                        <configuration>
-                            <target>
-                                <taskdef name="groovyc" classname="org.codehaus.groovy.ant.Groovyc">
-                                    <classpath refid="maven.compile.classpath" />
-                                </taskdef>
-                                <mkdir dir="${project.build.outputDirectory}" />
-                                <groovyc srcdir="${basedir}/src/main/groovy" destdir="${project.build.outputDirectory}" encoding="${project.build.sourceEncoding}">
-                                    <classpath refid="maven.compile.classpath" />
-                                </groovyc>
-                            </target>
-                        </configuration>
                         <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <phase>generate-test-sources</phase>
-                        <configuration>
-                            <target>
-                                <taskdef name="groovyc" classname="org.codehaus.groovy.ant.Groovyc">
-                                    <classpath refid="maven.test.classpath" />
-                                </taskdef>
-                                <mkdir dir="${project.build.testOutputDirectory}" />
-                                <groovyc srcdir="${basedir}/src/test/groovy" destdir="${project.build.testOutputDirectory}" encoding="${project.build.sourceEncoding}">
-                                    <classpath refid="maven.test.classpath" />
-                                </groovyc>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
+                            <goal>addSources</goal>
+                            <goal>addTestSources</goal>
+                            <goal>generateStubs</goal>
+                            <goal>compile</goal>
+                            <goal>testGenerateStubs</goal>
+                            <goal>testCompile</goal>
+                            <goal>removeStubs</goal>
+                            <goal>removeTestStubs</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4287

Switch groovy compilation to GMavenPlus to allow:
- groovy files to depend upon java classes
- groovy unit tests to execute against java classes (should allow for spock-based unit tests as well)
- groovy api docs to be included with java api docs

Currently no groovy classes need this.  This change set came about when trying to create a groovy PersonDirectoryDao class that needed to invoke uPortal java code to do its job.  It was not possible with the maven antrun groovyc compilation process.
