### PR TITLE
UP-4294v2: Removed jQuery animation, added CSS animation

### DIFF
--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -252,18 +252,6 @@
                 </div>
               </div>
             </div>
-
-            <script type="text/javascript">
-              up.jQuery(document).ready(function() {
-                var $ = up.jQuery;
-                  $('.no-chrome').hover(function() {
-                    $(this).find('.hover-toolbar').stop(true, true).show('slow');
-                  },
-                  function() {
-                    $(this).find('.hover-toolbar').stop(true, true).hide('slow');
-                });
-              });
-            </script>
           </xsl:when>
 
           <!-- ***** RENDER CHROME ***** -->

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/no-chrome.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/no-chrome.less
@@ -25,9 +25,13 @@
     }
 
     .hover-toolbar {
-        display: none;
         z-index: 1000;
         position: absolute;
+        opacity: 0;
+        transition: opacity 0.25s ease-in-out;
+        -moz-transition: opacity 0.25s ease-in-out;
+        -webkit-transition: opacity 0.25s ease-in-out;
+
 
         .up-portlet-titlebar {
             background-color: @grayscale2;
@@ -49,6 +53,13 @@
                     right: auto !important;
                 }
             }
+        }
+    }
+
+    &:hover {
+        .hover-toolbar {
+            opacity: 1.0;
+
         }
     }
 }


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4294

jQuery animation was not working, so removed script and added CSS animation to .hover-toolbar instead (in no-chrome.less)
