### PR TITLE
UP-4223 Prevent duplicate sticky profile selection storage attempts

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/profile/ProfileSelectionRegistry.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/profile/ProfileSelectionRegistry.java
@@ -69,10 +69,10 @@ public class ProfileSelectionRegistry
             // non-null profileFName translates to creating or updating a Selection.
 
             if (null == existingSelection) {
-                this.profileSelectionDao.createProfileSelection(userName, profileFName);
+                this.profileSelectionDao.createOrUpdateProfileSelection(userName, profileFName);
             } else {
                 existingSelection.setProfileFName(profileFName);
-                this.profileSelectionDao.updateProfileSelection(existingSelection);
+                this.profileSelectionDao.createOrUpdateProfileSelection(existingSelection);
             }
 
         }

--- a/uportal-war/src/main/java/org/jasig/portal/layout/profile/dao/IProfileSelectionDao.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/profile/dao/IProfileSelectionDao.java
@@ -30,15 +30,14 @@ import org.jasig.portal.layout.profile.IProfileSelection;
 public interface IProfileSelectionDao {
 
     /**
-     * Creates, initializes, and persists a new {@link org.jasig.portal.layout.profile.IProfileSelection}
-     * representing the given user's selection of the given profile.
+     * Updates a {@link IProfileSelection} or creates a new if one doesn't exist.
      * @param userName non-null username of user who has made the selection
      * @param profileFName fname of the selected profile, or null indicating no selection
-     * @return a newly created, initialized, and persisted {@link org.jasig.portal.layout.profile.IProfileSelection}
+     * @return a managed entity {@link IProfileSelection} representing the params
      * @throws IllegalArgumentException if userName is null
      * @throws org.springframework.dao.DataIntegrityViolationException if the user already has a profile selection.
      */
-    public IProfileSelection createProfileSelection(String userName, String profileFName);
+    public IProfileSelection createOrUpdateProfileSelection(String userName, String profileFName);
 
     /**
      * Get the {@link IProfileSelection} for the given user, or null if that user has no persisted selection.
@@ -49,12 +48,12 @@ public interface IProfileSelectionDao {
     public IProfileSelection readProfileSelectionForUser(String userName);
 
     /**
-     * Persists changes to a {@link IProfileSelection}.
+     * Updates a {@link IProfileSelection} or creates a new if one doesn't exist.
      * @param profileSelection non-null potentially changed profileSelection to be persisted.
-     * @return the same profile selection, with its change persisted.
+     * @return a managed entity
      * @throws java.lang.IllegalArgumentException if profileSelection is null
      */
-    public IProfileSelection updateProfileSelection(IProfileSelection profileSelection);
+    public IProfileSelection createOrUpdateProfileSelection(IProfileSelection profileSelection);
 
     /**
      * Removes the specified {@link IProfileSelection} from the persistent store.

--- a/uportal-war/src/main/java/org/jasig/portal/layout/profile/dao/jpa/ProfileSelectionDaoImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/profile/dao/jpa/ProfileSelectionDaoImpl.java
@@ -36,32 +36,31 @@ public class ProfileSelectionDaoImpl
     extends BasePortalJpaDao
     implements IProfileSelectionDao {
 
-
     @Override
     @PortalTransactional
-    public IProfileSelection createProfileSelection(final String userName, final String profileFName) {
-
+    public IProfileSelection createOrUpdateProfileSelection(final String userName, final String profileFName){
         Validate.notEmpty(userName, "Cannot create a profile selection for an empty userName");
         Validate.notEmpty(profileFName,
                 "Cannot create profile selection with empty profile fname " +
                         "(instead delete any selection for this user.)");
 
         final ProfileSelection jpaProfileSelection = new ProfileSelection(userName, profileFName);
-
-        getEntityManager().persist(jpaProfileSelection);
-
-        return jpaProfileSelection;
+        return this.createOrUpdateProfileSelection(jpaProfileSelection);
     }
 
     @Override
     @PortalTransactional
-    public IProfileSelection updateProfileSelection(final IProfileSelection profileSelection) {
+    public IProfileSelection createOrUpdateProfileSelection(final IProfileSelection profileSelection){
 
         Validate.notNull(profileSelection);
-
-        getEntityManager().persist(profileSelection);
-
-        return profileSelection;
+        
+        if(!getEntityManager().contains(profileSelection)){
+            //Entity is not managed
+            return getEntityManager().merge(profileSelection);
+        }else{
+            getEntityManager().persist(profileSelection);
+            return profileSelection;
+        }
     }
 
     @Override


### PR DESCRIPTION
There has been a weird error that pops up from time to time in our test and production tiers.  We can never reliably reproduce them.  We can also never quite pinpoint the error.  Since the error isn't caught, the user is redirected to our generic portal error page.  A simple refresh solves the problem.

Error:
`ERROR [ajp-bio-127.0.0.1-8009-exec-135-vertein] o.h.e.j.batch.internal.BatchingBatch 2014-12-01 12:21:56,401 - HHH000315: Exception executing batch [ORA-00001: unique constraint (MYQA40.SYS_C00171188) violated
]
ERROR [ajp-bio-127.0.0.1-8009-exec-135] o.j.p.web.ExceptionLoggingFilter 2014-12-01 12:21:56,530 - uPortal: unhandled exception 'ORA-00001: unique constraint (MYQA40.SYS_C00171188) violated
; SQL [n/a]; constraint [MYQA40.SYS_C00171188]; nested exception is org.hibernate.exception.ConstraintViolationException: ORA-00001: unique constraint (MYQA40.SYS_C00171188) violated
' for URL=/portal/Login?profile=bucky, user=vertein , from IP=128.104.17.46
org.springframework.dao.DataIntegrityViolationException: ORA-00001: unique constraint (MYQA40.SYS_C00171188) violated
; SQL [n/a]; constraint [MYQA40.SYS_C00171188]; nested exception is org.hibernate.exception.ConstraintViolationException: ORA-00001: unique constraint (MYQA40.SYS_C00171188) violated`

`at org.springframework.orm.hibernate3.SessionFactoryUtils.convertHibernateAccessException(SessionFactoryUtils.java:643) ~[spring-orm-3.1.4.RELEASE.jar:3.1.4.RELEASE]
    at org.springframework.orm.jpa.vendor.HibernateJpaDialect.translateExceptionIfPossible(HibernateJpaDialect.java:104) ~[spring-orm-3.1.4.RELEASE.jar:3.1.4.RELEASE]
    at org.springframework.orm.jpa.JpaTransactionManager.doCommit(JpaTransactionManager.java:516) ~[spring-orm-3.1.4.RELEASE.jar:3.1.4.RELEASE]
    at org.springframework.transaction.support.AbstractPlatformTransactionManager.processCommit(AbstractPlatformTransactionManager.java:754) ~[spring-tx-3.1.4.RELEASE.jar:3.1.4.RELEASE]
    at org.springframework.transaction.support.AbstractPlatformTransactionManager.commit(AbstractPlatformTransactionManager.java:723) ~[spring-tx-3.1.4.RELEASE.jar:3.1.4.RELEASE]
    at org.springframework.transaction.interceptor.TransactionAspectSupport.commitTransactionAfterReturning(TransactionAspectSupport.java:387) ~[spring-tx-3.1.4.RELEASE.jar:3.1.4.RELEASE]
    at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:120) ~[spring-tx-3.1.4.RELEASE.jar:3.1.4.RELEASE]
    at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:172) ~[spring-aop-3.1.4.RELEASE.jar:3.1.4.RELEASE]
    at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:202) ~[spring-aop-3.1.4.RELEASE.jar:3.1.4.RELEASE]
    at com.sun.proxy.$Proxy437.registerUserProfileSelection(Unknown Source) ~[na:na]
    at org.jasig.portal.layout.profile.StickyProfileMapperImpl.onApplicationEvent(StickyProfileMapperImpl.java:124) ~[StickyProfileMapperImpl.class:na]
    at org.jasig.portal.layout.profile.StickyProfileMapperImpl.onApplicationEvent(StickyProfileMapperImpl.java:60) ~[StickyProfileMapperImpl.class:na]
`

Constraint (name, table, column_name): 
`SYS_C00171188  UP_PROFILE_SELECTION    USERNAME`

I think sometimes it tries to insert twice.  This just guards against the consequences of this.
