### PR TITLE
UP-4332 Create transient tab for portlets not on user's layout

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/TransientUserLayoutXMLEventReader.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/TransientUserLayoutXMLEventReader.java
@@ -31,20 +31,21 @@ import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.jasig.portal.portlet.om.IPortletDefinition;
 import org.jasig.portal.portlet.om.IPortletDefinitionParameter;
 import org.jasig.portal.xml.stream.InjectingXMLEventReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
+ * XMLEventReader that can return dynamically created content to add into the document.
+ *
  * @author Eric Dalquist
- * @version $Revision$
  */
 public class TransientUserLayoutXMLEventReader extends InjectingXMLEventReader {
     private static final XMLEventFactory EVENT_FACTORY = XMLEventFactory.newFactory();
 
-    protected final Log logger = LogFactory.getLog(this.getClass());
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
     
     private final TransientUserLayoutManagerWrapper userLayoutManager;
     private final String rootFolderId;
@@ -56,7 +57,14 @@ public class TransientUserLayoutXMLEventReader extends InjectingXMLEventReader {
         this.userLayoutManager = userLayoutManager;
         this.rootFolderId = this.userLayoutManager.getRootFolderId();
     }
-    
+
+    /**
+     * Examines the current token and when appropriate creates and returns dynamically created content.
+     * If dynamic content is not created, return null.
+     *
+     * @param event The current event
+     * @return  Dynamic content to inject into document, else null if no additional dynamic content was created.
+     */
     @Override
     protected Deque<XMLEvent> getAdditionalEvents(XMLEvent event) {
         if (event.isStartElement()) {
@@ -68,77 +76,98 @@ public class TransientUserLayoutXMLEventReader extends InjectingXMLEventReader {
                 return null;
             }
             
-            //Handle adding a transient folder to the root element
-            if (this.rootFolderId.equals(idAttribute.getValue())) {
-                final QName name = startElement.getName();
-                final String namespaceURI = name.getNamespaceURI();
-                final String prefix = name.getPrefix();
-                
-                final Deque<XMLEvent> transientEventBuffer = new LinkedList<XMLEvent>();
-                
-                final Collection<Attribute> transientFolderAttributes = new LinkedList<Attribute>();
-                transientFolderAttributes.add(EVENT_FACTORY.createAttribute("ID", TransientUserLayoutManagerWrapper.TRANSIENT_FOLDER_ID));
-                transientFolderAttributes.add(EVENT_FACTORY.createAttribute("type", "regular"));
-                transientFolderAttributes.add(EVENT_FACTORY.createAttribute("hidden", "true"));
-                transientFolderAttributes.add(EVENT_FACTORY.createAttribute("unremovable", "true"));
-                transientFolderAttributes.add(EVENT_FACTORY.createAttribute("immutable", "true"));
-                transientFolderAttributes.add(EVENT_FACTORY.createAttribute("name", "Transient Folder"));
-                
-                final StartElement transientFolder = EVENT_FACTORY.createStartElement(prefix, namespaceURI, IUserLayoutManager.FOLDER, transientFolderAttributes.iterator(), null);
-                transientEventBuffer.add(transientFolder);
+            // Create and return a transient (dynamically created) folder that includes a transient channel
+            // if we are processing the tart element of the root node
+            // iff the subscribeId is present and describes a transient channel and not a regular layout channel.
+            final String subscribeId = this.userLayoutManager.getFocusedId();
+            if (this.rootFolderId.equals(idAttribute.getValue())
+                    && subscribeId != null && !subscribeId.equals("")
+                    && this.userLayoutManager.isTransientChannel(subscribeId)) {
 
-                //append channel element iff subscribeId describes a transient channel, and not a regular layout channel
-                final String subscribeId = this.userLayoutManager.getFocusedId();
-                if (null != subscribeId && !subscribeId.equals("") && this.userLayoutManager.isTransientChannel(subscribeId)) {
-                    IPortletDefinition chanDef = null;
-                    try {
-                        chanDef = this.userLayoutManager.getChannelDefinition(subscribeId);
-                    }
-                    catch (Exception e) {
-                        this.logger.error("Could not obtain IChannelDefinition for subscribe id: " + subscribeId, e);
-                    }
-                    
-                    if (chanDef != null) {
-                        //TODO Move IChannelDefinition/IPortletDefinition -> StAX events code somewhere reusable
-                        final Collection<Attribute> channelAttrs = new LinkedList<Attribute>();
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("ID", subscribeId));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("typeID", Integer.toString(chanDef.getType().getId())));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("hidden", "false"));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("unremovable", "true"));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("name", chanDef.getName()));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("description", chanDef.getDescription()));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("title", chanDef.getTitle()));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("chanID", chanDef.getPortletDefinitionId().getStringId()));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("fname", chanDef.getFName()));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("timeout", Integer.toString(chanDef.getTimeout())));
-                        channelAttrs.add(EVENT_FACTORY.createAttribute("transient", "true"));
-
-                        final StartElement startChannel = EVENT_FACTORY.createStartElement(prefix, namespaceURI, IUserLayoutManager.CHANNEL, channelAttrs.iterator(), null);
-                        transientEventBuffer.offer(startChannel);
-
-                        // add channel parameter elements
-                        for(final IPortletDefinitionParameter parm : chanDef.getParameters())
-                        {
-                            final Collection<Attribute> parameterAttrs = new LinkedList<Attribute>();
-                            parameterAttrs.add(EVENT_FACTORY.createAttribute("name",parm.getName()));
-                            parameterAttrs.add(EVENT_FACTORY.createAttribute("value",parm.getValue()));
-
-                            final StartElement startParameter = EVENT_FACTORY.createStartElement(prefix, namespaceURI, IUserLayoutManager.PARAMETER, parameterAttrs.iterator(), null);
-                            transientEventBuffer.offer(startParameter);
-                            
-                            final EndElement endParameter = EVENT_FACTORY.createEndElement(prefix, namespaceURI, IUserLayoutManager.PARAMETER, null);
-                            transientEventBuffer.offer(endParameter);
-                        }
-
-                        final EndElement endChannel = EVENT_FACTORY.createEndElement(prefix, namespaceURI, IUserLayoutManager.CHANNEL, null);
-                        transientEventBuffer.offer(endChannel);
-                    }
+                IPortletDefinition chanDef = null;
+                try {
+                    chanDef = this.userLayoutManager.getChannelDefinition(subscribeId);
                 }
-                
-                final EndElement endFolder = EVENT_FACTORY.createEndElement(prefix, namespaceURI, IUserLayoutManager.FOLDER, null);
-                transientEventBuffer.offer(endFolder);
-                
-                return transientEventBuffer;
+                catch (Exception e) {
+                    logger.error("Could not obtain IChannelDefinition for subscribe id: {}", subscribeId, e);
+                }
+
+                if (chanDef != null) {
+                    final QName name = startElement.getName();
+                    final String namespaceURI = name.getNamespaceURI();
+                    final String prefix = name.getPrefix();
+
+                    final Deque<XMLEvent> transientEventBuffer = new LinkedList<XMLEvent>();
+
+                    final Collection<Attribute> transientFolderAttributes = new LinkedList<Attribute>();
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("ID",
+                            TransientUserLayoutManagerWrapper.TRANSIENT_FOLDER_ID));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("name",
+                            chanDef != null ? chanDef.getTitle() : "Temporary"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("type", "regular"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("hidden", "false"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("unremovable", "true"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("immutable", "true"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("unremovable", "true"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("dlm:addChildAllowed", "false"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("dlm:deleteAllowed", "false"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("dlm:editAllowed", "false"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("dlm:moveAllowed", "false"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("dlm:precedence", "100.0"));
+                    transientFolderAttributes.add(EVENT_FACTORY.createAttribute("transient", "true"));
+
+                    final StartElement transientFolder = EVENT_FACTORY.createStartElement(prefix, namespaceURI,
+                            IUserLayoutManager.FOLDER, transientFolderAttributes.iterator(), null);
+                    transientEventBuffer.add(transientFolder);
+
+                    //TODO Move IChannelDefinition/IPortletDefinition -> StAX events code somewhere reusable
+                    final Collection<Attribute> channelAttrs = new LinkedList<Attribute>();
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("ID", subscribeId));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("typeID", Integer.toString(chanDef.getType().getId())));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("hidden", "false"));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("unremovable", "true"));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("dlm:deleteAllowed", "false"));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("dlm:moveAllowed", "false"));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("name", chanDef.getName()));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("description", chanDef.getDescription()));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("title", chanDef.getTitle()));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("chanID", chanDef.getPortletDefinitionId().getStringId()));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("fname", chanDef.getFName()));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("timeout", Integer.toString(chanDef.getTimeout())));
+                    channelAttrs.add(EVENT_FACTORY.createAttribute("transient", "true"));
+
+                    final StartElement startChannel = EVENT_FACTORY.createStartElement(prefix, namespaceURI,
+                            IUserLayoutManager.CHANNEL, channelAttrs.iterator(), null);
+                    transientEventBuffer.offer(startChannel);
+
+                    // add channel parameter elements
+                    for(final IPortletDefinitionParameter parm : chanDef.getParameters())
+                    {
+                        final Collection<Attribute> parameterAttrs = new LinkedList<Attribute>();
+                        parameterAttrs.add(EVENT_FACTORY.createAttribute("name",parm.getName()));
+                        parameterAttrs.add(EVENT_FACTORY.createAttribute("value",parm.getValue()));
+
+                        final StartElement startParameter = EVENT_FACTORY.createStartElement(prefix, namespaceURI,
+                                IUserLayoutManager.PARAMETER, parameterAttrs.iterator(), null);
+                        transientEventBuffer.offer(startParameter);
+
+                        final EndElement endParameter = EVENT_FACTORY.createEndElement(prefix, namespaceURI,
+                                IUserLayoutManager.PARAMETER, null);
+                        transientEventBuffer.offer(endParameter);
+                    }
+
+                    final EndElement endChannel = EVENT_FACTORY.createEndElement(prefix, namespaceURI,
+                            IUserLayoutManager.CHANNEL, null);
+                    transientEventBuffer.offer(endChannel);
+
+                    final EndElement endFolder = EVENT_FACTORY.createEndElement(prefix, namespaceURI,
+                            IUserLayoutManager.FOLDER, null);
+                    transientEventBuffer.offer(endFolder);
+
+                    return transientEventBuffer;
+                } else { // I don't think subscribeId could be null, but log warning if so.
+                    logger.warn("Unable to resolve portlet definition for subscribe ID {}", subscribeId);
+                }
             }
         }
         

--- a/uportal-war/src/main/java/org/jasig/portal/url/processing/UserLayoutParameterProcessor.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/processing/UserLayoutParameterProcessor.java
@@ -24,8 +24,6 @@ import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.jasig.portal.IUserPreferencesManager;
 import org.jasig.portal.layout.IStylesheetUserPreferencesService;
 import org.jasig.portal.layout.IStylesheetUserPreferencesService.PreferencesScope;
@@ -42,6 +40,8 @@ import org.jasig.portal.url.IUrlSyntaxProvider;
 import org.jasig.portal.url.UrlState;
 import org.jasig.portal.user.IUserInstance;
 import org.jasig.portal.user.IUserInstanceManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -95,6 +95,16 @@ public class UserLayoutParameterProcessor implements IRequestParameterProcessor 
         final String tabId = portalRequestInfo.getTargetedLayoutNodeId();
         if (tabId != null) {
             this.stylesheetUserPreferencesService.setStylesheetParameter(request, PreferencesScope.STRUCTURE, "focusedTabID", tabId);
+        }
+
+        // If the layout manager is a transient layout manager, reset the focusedId.  This addresses the use case of a
+        // user focusing on a transient portlet (one not on their layout), then doing something like clicking on
+        // another tab.  If we didn't reset the focused ID the layout processing will again create a transient folder
+        // and portlet node even though the current URL doesn't specify focusing on a portlet. If the URL does focus
+        // on a portlet, it will get overwritten with the new value below.
+        if (userLayoutManager instanceof TransientUserLayoutManagerWrapper) {
+            final TransientUserLayoutManagerWrapper transientUserLayoutManagerWrapper = (TransientUserLayoutManagerWrapper) userLayoutManager;
+            transientUserLayoutManagerWrapper.setFocusedId(null);
         }
 
         final UrlState urlState = portalRequestInfo.getUrlState();

--- a/uportal-war/src/main/java/org/jasig/portal/url/xml/XsltPortalUrlProvider.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/xml/XsltPortalUrlProvider.java
@@ -105,7 +105,7 @@ public class XsltPortalUrlProvider {
             return this.portalUrlProvider.getDefaultUrl(request);
         }
         catch (Exception e) {
-            this.logger.error("Faild to create IPortalUrlBuilder for fname='" + fname + "', layoutId='" + layoutId + "', type='" + type +"'. # will be returned instead.", e);
+            this.logger.error("Failed to create IPortalUrlBuilder for fname='" + fname + "', layoutId='" + layoutId + "', type='" + type +"'. # will be returned instead.", e);
             return new FailSafePortalUrlBuilder();
         }
     }

--- a/uportal-war/src/main/java/org/jasig/portal/xml/stream/InjectingXMLEventReader.java
+++ b/uportal-war/src/main/java/org/jasig/portal/xml/stream/InjectingXMLEventReader.java
@@ -47,12 +47,6 @@ public abstract class InjectingXMLEventReader extends BaseXMLEventReader {
         
         final XMLEvent event = this.getParent().nextEvent();
         this.additionalEvents = this.getAdditionalEvents(event);
-        if (this.additionalEvents != null) {
-            //Stick the current event at the bottom of the deque so it isn't forgotten
-            this.additionalEvents.offer(event);
-            return this.additionalEvents.pop();
-        }
-        
         return event;
     }
 

--- a/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/content.xsl
@@ -433,14 +433,9 @@
         </li>
       </xsl:if>
 
-      <!-- Return from Focused Icon -->
-      <xsl:if test="//focused">
+      <!-- Return from Focused Icon. Don't display for transient portlets. -->
+      <xsl:if test="//focused and not(@transient='true')">
         <xsl:variable name="portletReturnUrl">
-          <xsl:choose>
-            <xsl:when test="@transient='true'">
-              <xsl:call-template name="portalUrl" />
-            </xsl:when>
-            <xsl:otherwise>
               <xsl:call-template name="portalUrl">
                 <xsl:with-param name="url">
                   <url:portal-url>
@@ -449,8 +444,6 @@
                   </url:portal-url>
                 </xsl:with-param>
               </xsl:call-template>
-            </xsl:otherwise>
-          </xsl:choose>
         </xsl:variable>
         <li>
           <a href="{$portletReturnUrl}" title="{upMsg:getMessage('return.to.dashboard.view', $USER_LANG)}" class="up-portlet-control return"><xsl:value-of select="upMsg:getMessage('return.to.dashboard', $USER_LANG)"/></a>

--- a/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -180,6 +180,12 @@
         <xsl:otherwise></xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
+    <xsl:variable name="NAV_TRANSIENT">
+      <xsl:choose>
+        <xsl:when test="@transient='true'">disabled</xsl:when>
+        <xsl:otherwise></xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
     <xsl:variable name="NAV_INLINE_EDITABLE"><!--Determine which navigation tab has edit permissions and is the active tab. Class name is leveraged by the fluid inline editor component.-->
         <xsl:choose>
             <xsl:when test="$AUTHENTICATED='true'">
@@ -230,15 +236,21 @@
     </xsl:variable>
     <li id="portalNavigation_{@ID}" class="portal-navigation {$NAV_POSITION} {$NAV_ACTIVE} {$NAV_MOVABLE} {$NAV_EDITABLE} {$NAV_DELETABLE} {$NAV_CAN_ADD_CHILDREN}"> <!-- Each navigation menu item.  The unique ID can be used in the CSS to give each menu item a unique icon, color, or presentation. -->
       <xsl:variable name="tabLinkUrl">
-        <xsl:call-template name="portalUrl">
-          <xsl:with-param name="url">
-            <url:portal-url>
-                <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-            </url:portal-url>
-          </xsl:with-param>
-        </xsl:call-template>
+        <!-- For transient tabs, don't try to calculate an URL.  It display an exception in the logs. Use a safe URL. -->
+        <xsl:choose>
+            <xsl:when test="@transient='true'">javascript:;</xsl:when>
+            <xsl:otherwise>
+                <xsl:call-template name="portalUrl">
+                    <xsl:with-param name="url">
+                        <url:portal-url>
+                            <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
+                        </url:portal-url>
+                    </xsl:with-param>
+                </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
       </xsl:variable>
-      <a id="tabLink_{@ID}" href="{$tabLinkUrl}" title="{@name}" class="portal-navigation-link {$NAV_INLINE_EDITABLE}">
+      <a id="tabLink_{@ID}" href="{$tabLinkUrl}" title="{@name}" class="portal-navigation-link {$NAV_INLINE_EDITABLE} {$NAV_TRANSIENT}">
         <span title="{$NAV_INLINE_EDIT_TITLE}" class="portal-navigation-label {$NAV_INLINE_EDIT_TEXT}">
           <xsl:value-of select="upElemTitle:getTitle(@ID, $USER_LANG, @name)"/>
         </span>
@@ -268,59 +280,6 @@
 
   </xsl:template>
   <!-- ========================================== -->
-
-
-  <!-- ========== TEMPLATE: PORTLET NAVIGATION ========== -->
-  <!-- ================================================== -->
-  <!--
-   | This template renders portlet navigation when a portlet is focused.
-  -->
-  <xsl:template name="portlet.navigation">
-    <div id="portletNavigation" class="fl-widget">
-        <div class="fl-widget-inner">
-        <div class="fl-widget-titlebar">
-            <h2><xsl:value-of select="upMsg:getMessage('jump.to', $USER_LANG)"/>:</h2>
-        </div>
-        <div class="fl-widget-content">
-            <ul class="fl-listmenu">
-            <li id="portletNavigationLinkHome">
-                <xsl:variable name="homeUrl">
-                  <xsl:call-template name="portalUrl"/>
-                </xsl:variable>
-                <a href="{$homeUrl}" title="{upMsg:getMessage('go.back.to.home', $USER_LANG)}">
-                <span>
-                    <xsl:value-of select="upMsg:getMessage('home', $USER_LANG)"/>
-                </span>
-              </a>
-            </li>
-          </ul>
-          <xsl:for-each select="//navigation/tab">
-            <xsl:variable name="TAB_POSITION" select="position()"/>
-            <h3><xsl:value-of select="@name"/></h3>
-            <ul class="fl-listmenu">
-              <xsl:for-each select="tabChannel">
-                <li>
-                  <xsl:variable name="tabLinkUrl">
-                    <xsl:call-template name="portalUrl">
-                        <xsl:with-param name="url">
-                          <url:portal-url>
-                              <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                          </url:portal-url>
-                        </xsl:with-param>
-                    </xsl:call-template>
-                  </xsl:variable>
-                  <a href="{$tabLinkUrl}" title="{@name}">  <!-- Navigation item link. -->
-                    <span><xsl:value-of select="@name"/></span>
-                  </a>
-                </li>
-              </xsl:for-each>
-            </ul>
-          </xsl:for-each>
-            </div>
-      </div>
-    </div>
-  </xsl:template>
-  <!-- ================================================== -->
 
 
   <!-- ========== TEMPLATE: SUBNAVIGATION ========== -->

--- a/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
+++ b/uportal-war/src/main/resources/layout/theme/respondr/respondr.xsl
@@ -320,17 +320,30 @@
                     <div class="row">
                         <xsl:for-each select="//navigation/tab">
                             <xsl:if test="ceiling(position() div $TAB_WRAP_COUNT) = $ROW_NUM">
+                                <xsl:variable name="NAV_TRANSIENT">
+                                    <xsl:choose>
+                                        <xsl:when test="@transient='true'">disabled</xsl:when>
+                                        <xsl:otherwise></xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:variable>
                                 <xsl:variable name="tabLinkUrl">
-                                    <xsl:call-template name="portalUrl">
-                                        <xsl:with-param name="url">
-                                            <url:portal-url>
-                                                <url:layoutId><xsl:value-of select="@ID" /></url:layoutId>
-                                            </url:portal-url>
-                                        </xsl:with-param>
-                                    </xsl:call-template>
+                                    <!-- For a transient tab, attempting to calculate a tab URL generates an
+                                         exception because the tab is not in the layout so generate a safe URL. -->
+                                    <xsl:choose>
+                                        <xsl:when test="@transient='true'">javascript:;</xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:call-template name="portalUrl">
+                                                <xsl:with-param name="url">
+                                                    <url:portal-url>
+                                                        <url:layoutId><xsl:value-of select="@ID" /></url:layoutId>
+                                                    </url:portal-url>
+                                                </xsl:with-param>
+                                            </xsl:call-template>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
                                 </xsl:variable>
                                 <div class="col-md-3">
-                                    <h4><a href="{$tabLinkUrl}"><xsl:value-of select="upElemTitle:getTitle(@ID, $USER_LANG, @name)"/></a></h4>
+                                    <h4><a href="{$tabLinkUrl}" class="{$NAV_TRANSIENT}"><xsl:value-of select="upElemTitle:getTitle(@ID, $USER_LANG, @name)"/></a></h4>
                                     <ul>
                                         <xsl:for-each select="tabChannel">
                                             <xsl:variable name="portletLinkUrl">

--- a/uportal-war/src/main/resources/layout/theme/universality/navigation.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/navigation.xsl
@@ -218,6 +218,12 @@
             <xsl:otherwise></xsl:otherwise>
           </xsl:choose>
         </xsl:variable>
+        <xsl:variable name="NAV_TRANSIENT">
+            <xsl:choose>
+                <xsl:when test="@transient='true'">disabled</xsl:when>
+                <xsl:otherwise></xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
         <xsl:variable name="NAV_INLINE_EDITABLE"><!--Determine which navigation tab has edit permissions and is the active tab. Class name is leveraged by the fluid inline editor component.-->
             <xsl:choose>
                 <xsl:when test="$AUTHENTICATED='true'">
@@ -271,15 +277,22 @@
         </xsl:variable>
         <li id="portalNavigation_{@ID}" class="portal-navigation {$NAV_POSITION} {$NAV_ACTIVE} {$NAV_MOVABLE} {$NAV_EDITABLE} {$NAV_DELETABLE} {$NAV_CAN_ADD_CHILDREN}"> <!-- Each navigation menu item.  The unique ID can be used in the CSS to give each menu item a unique icon, color, or presentation. -->
           <xsl:variable name="tabLinkUrl">
-            <xsl:call-template name="portalUrl">
-              <xsl:with-param name="url">
-                <url:portal-url>
-                    <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
-                </url:portal-url>
-              </xsl:with-param>
-            </xsl:call-template>
+              <!-- For a transient tab, attempting to calculate a tab URL generates an
+                   exception because the tab is not in the layout so generate a safe URL. -->
+              <xsl:choose>
+                  <xsl:when test="@transient='true'">javascript:;</xsl:when>
+                  <xsl:otherwise>
+                    <xsl:call-template name="portalUrl">
+                      <xsl:with-param name="url">
+                        <url:portal-url>
+                            <url:layoutId><xsl:value-of select="@ID"/></url:layoutId>
+                        </url:portal-url>
+                      </xsl:with-param>
+                    </xsl:call-template>
+                  </xsl:otherwise>
+              </xsl:choose>
           </xsl:variable>
-          <a id="tabLink_{@ID}" href="{$tabLinkUrl}" title="{@name}" class="portal-navigation-link {$NAV_INLINE_EDITABLE}">
+          <a id="tabLink_{@ID}" href="{$tabLinkUrl}" title="{@name}" class="portal-navigation-link {$NAV_INLINE_EDITABLE} {$NAV_TRANSIENT}">
             <span title="{$NAV_INLINE_EDIT_TITLE}" class="portal-navigation-label {$NAV_INLINE_EDIT_TEXT}">
               <xsl:value-of select="upElemTitle:getTitle(@ID, $USER_LANG, @name)"/>
             </span>

--- a/uportal-war/src/main/resources/layout/theme/universality/universality.xsl
+++ b/uportal-war/src/main/resources/layout/theme/universality/universality.xsl
@@ -916,17 +916,30 @@
             <div class="fl-container-flex fl-col-flex4">
               <xsl:for-each select="//navigation/tab">
                 <xsl:if test="ceiling(position() div $TAB_WRAP_COUNT) = $ROW_NUM">
+                    <xsl:variable name="NAV_TRANSIENT">
+                        <xsl:choose>
+                            <xsl:when test="@transient='true'">disabled</xsl:when>
+                            <xsl:otherwise></xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:variable>
                     <xsl:variable name="tabLinkUrl">
-                      <xsl:call-template name="portalUrl">
-                        <xsl:with-param name="url">
-                          <url:portal-url>
-                            <url:layoutId><xsl:value-of select="@ID" /></url:layoutId>
-                          </url:portal-url>
-                        </xsl:with-param>
-                      </xsl:call-template>
+                        <!-- For a transient tab, attempting to calculate a tab URL generates an
+                             exception because the tab is not in the layout so generate a safe URL. -->
+                        <xsl:choose>
+                            <xsl:when test="@transient='true'">javascript:;</xsl:when>
+                            <xsl:otherwise>
+                              <xsl:call-template name="portalUrl">
+                                <xsl:with-param name="url">
+                                  <url:portal-url>
+                                    <url:layoutId><xsl:value-of select="@ID" /></url:layoutId>
+                                  </url:portal-url>
+                                </xsl:with-param>
+                              </xsl:call-template>
+                            </xsl:otherwise>
+                        </xsl:choose>
                     </xsl:variable>
                     <div class="fl-col">
-                      <div><a href="{$tabLinkUrl}"><xsl:value-of select="upElemTitle:getTitle(@ID, $USER_LANG, @name)"/></a></div>
+                      <div><a href="{$tabLinkUrl}" class="{$NAV_TRANSIENT}"><xsl:value-of select="upElemTitle:getTitle(@ID, $USER_LANG, @name)"/></a></div>
                       <ul>
                           <xsl:for-each select="tabChannel">
                             <xsl:variable name="portletLinkUrl">

--- a/uportal-war/src/main/resources/org/jasig/portal/portlets/sitemap/sitemap.xsl
+++ b/uportal-war/src/main/resources/org/jasig/portal/portlets/sitemap/sitemap.xsl
@@ -119,17 +119,30 @@
   </xsl:template>
 
   <xsl:template match="folder" mode="tab">
+    <xsl:variable name="NAV_TRANSIENT">
+      <xsl:choose>
+        <xsl:when test="@transient='true'">disabled</xsl:when>
+        <xsl:otherwise></xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
     <xsl:variable name="tabLinkUrl">
-      <xsl:call-template name="portalUrl">
-        <xsl:with-param name="url">
-          <url:portal-url>
-            <url:layoutId><xsl:value-of select="@ID" /></url:layoutId>
-          </url:portal-url>
-        </xsl:with-param>
-      </xsl:call-template>
+        <!-- For a transient tab, attempting to calculate a tab URL generates an
+             exception because the tab is not in the layout so generate a safe URL. -->
+        <xsl:choose>
+            <xsl:when test="@transient='true'">javascript:;</xsl:when>
+            <xsl:otherwise>
+              <xsl:call-template name="portalUrl">
+                <xsl:with-param name="url">
+                  <url:portal-url>
+                    <url:layoutId><xsl:value-of select="@ID" /></url:layoutId>
+                  </url:portal-url>
+                </xsl:with-param>
+              </xsl:call-template>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:variable>
     <div class="fl-col">
-      <div><a href="{$tabLinkUrl}"><xsl:value-of select="upElemTitle:getTitle(@ID, $USER_LANG, @name)"/></a></div>
+      <div><a href="{$tabLinkUrl}" class="{$NAV_TRANSIENT}"><xsl:value-of select="upElemTitle:getTitle(@ID, $USER_LANG, @name)"/></a></div>
       <ul><xsl:apply-templates select="folder" mode="column" /></ul>
     </div>
   </xsl:template>

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/footer.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/footer.less
@@ -36,12 +36,18 @@
             }
         }
 
-        h4 a {
-            color: @grayscale2;
-            margin: 0;
-
-            &:hover, &:focus {
+        h4 {
+            a {
                 color: @grayscale2;
+                margin: 0;
+
+                &:hover, &:focus {
+                    color: @grayscale2;
+                }
+            }
+            a.disabled {
+                pointer-events: none;
+                cursor: default;
             }
         }
 

--- a/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
+++ b/uportal-war/src/main/webapp/media/skins/respondr/common/less/navigation.less
@@ -57,8 +57,6 @@
                 text-decoration: none;
                 padding: 8px 14px;
 
-                
-
                 &:hover, &:focus {
                     background: @navbar-item-hover-background-color;
                     color: @navbar-item-hover-text-color;
@@ -71,6 +69,12 @@
                     display: none;
                 }
             }
+
+            a.portal-navigation-link.disabled {
+                pointer-events: none;
+                cursor: default;
+            }
+
             a.portal-navigation-link i {
                     float: right;
                     margin-top: 2px;

--- a/uportal-war/src/main/webapp/media/skins/universality/common/scss/_footer.scss
+++ b/uportal-war/src/main/webapp/media/skins/universality/common/scss/_footer.scss
@@ -49,6 +49,10 @@
             div > a:hover {
             	color: #699bc4;
             }
+		    div > a.disabled {
+			  pointer-events: none;
+			  cursor: default;
+		    }
             .fl-col {
             	margin-left: 0;
             	margin-right: 0.50%;

--- a/uportal-war/src/main/webapp/media/skins/universality/common/scss/_navigation.scss
+++ b/uportal-war/src/main/webapp/media/skins/universality/common/scss/_navigation.scss
@@ -5,7 +5,7 @@
  * Styles specific to navigation.
  */
 
-/* Portlet Navigation */
+/* Portal Navigation */
 .up {
 	#portalNavigation {
 		/* Main Navigation, rendered as a row of tabs. */
@@ -44,6 +44,10 @@
 			}
 			.portal-navigation-link, .fl-inlineEditContainer {
 			    padding: $navTabPadding;
+			}
+		    .portal-navigation-link.disabled {
+			  pointer-events: none;
+			  cursor: default;
 			}
 		}
 		.portal-navigation:hover, .portal-navigation:focus {

--- a/uportal-war/src/test/resources/org/jasig/portal/portlets/sitemap/layout.xml
+++ b/uportal-war/src/test/resources/org/jasig/portal/portlets/sitemap/layout.xml
@@ -21,8 +21,16 @@
 -->
 <?xml-stylesheet type="text/xsl" href="../../../../../../../main/resources/org/jasig/portal/portlets/sitemap/sitemap1.xsl" ?>
 <layout xmlns:dlm="http://www.uportal.org/layout/dlm" >
-  <folder ID="ft1" type="regular" hidden="true" unremovable="true" immutable="true" name="Transient Folder" width="100%" tabGroup="DEFAULT_TABGROUP"/>
   <folder ID="s1" hidden="false" immutable="false" locale="lv_LV" name="Root folder" type="root" unremovable="true" width="100%" tabGroup="DEFAULT_TABGROUP">
+    <folder ID="ft1" name="About.com College Life" type="regular" hidden="false" unremovable="true" immutable="true" dlm:addChildAllowed="false" dlm:deleteAllowed="false" dlm:editAllowed="false" dlm:moveAllowed="false" dlm:precedence="100.0" transient="true" width="100%" tabGroup="DEFAULT_TABGROUP">
+      <channel ID="ctf1" typeID="2" hidden="false" unremovable="true" dlm:deleteAllowed="false" dlm:moveAllowed="false" name="About.com College Life" description="About.com College Life RSS feed" title="About.com College Life" chanID="95" fname="about-college-life" timeout="10000" transient="true" windowState="maximized" portletMode="view">
+        <parameter name="iconUrl" value="/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/internet-news-reader.png"/>
+        <parameter name="hasHelp" value="true"/>
+        <parameter name="mobileIconUrl" value="/uPortal/media/skins/icons/mobile/feed.png"/>
+        <parameter name="editable" value="true"/>
+        <parameter name="disableDynamicTitle" value="true"/>
+      </channel>
+    </folder>
     <folder ID="u201l1s22" dlm:fragment="0" dlm:precedence="190.0" hidden="false" immutable="true" locale="lv_LV" name="Header folder" type="header" unremovable="true" width="100%" tabGroup="DEFAULT_TABGROUP"/>
     <folder ID="u201l1s4" dlm:fragment="0" dlm:precedence="190.0" hidden="false" immutable="false" locale="lv_LV" name="Footer folder" type="footer" unremovable="false" width="100%" tabGroup="DEFAULT_TABGROUP"/>
     <folder ID="u201l1s5" dlm:addChildAllowed="false" dlm:deleteAllowed="false" dlm:editAllowed="false" dlm:fragment="0" dlm:moveAllowed="false" dlm:precedence="190.0" hidden="false" immutable="false" locale="lv_LV" name="RBS" type="regular" unremovable="false" width="100%" tabGroup="Start">


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4332

As part of a broader issue (https://issues.jasig.org/browse/UP-4041) this commit alters uPortal functionality such that focusing on a portlet that is not on the user's layout (transient portlet) will open the portlet on a transient, temporary tab to display the portlet's content.  If the portlet is present on a user's layout, the portlet will be displayed in focus mode on the tab the portlet is present on, just like it currently does.

The current functionality is that the transient portlet would display on the first tab that is in the user's layout (Admin Tools tab in the case of the Admin).  
# New Functionality

The new functionality is
![up-4332dynamictab](https://cloud.githubusercontent.com/assets/1479823/5321800/daed3bb4-7c7b-11e4-855e-f9dbaa5621ad.png)

Further when displaying a transient portlet
- transient tab's name is the portlet's title
- transient tab cannot be clicked on since there is no valid URL to display a folder that is not on your layout.  Applies to site navigation also
- transient portlets do not receive a 'Return to desktop' link (Respondr only, didn't change Universality).  To display other content you click on another navigation link (tab name, portlet title in sitemap, etc.).  IMHO https://issues.jasig.org/browse/UP-3553 should be resolved before 'Return to desktop' is added in for transient portlets.

![auth user portlet not on layout](https://cloud.githubusercontent.com/assets/1479823/5321853/9b0dfd34-7c7c-11e4-8d9c-1a644df6d5ac.png)

This change does make for a slightly different Admin UI interaction since the Manage Portal launches transient portlet links.  Returning from say 'Manage Portlets' would be done by clicking on the Admin Tools tab as indicated above.  The following image illustrates Admin UI interaction in the adverse scenario of Admin Tools not being the admin's 1st tab (illustrates UP-3553 graphically as well).

![admin ui interaction](https://cloud.githubusercontent.com/assets/1479823/5321957/af07a352-7c7d-11e4-8d0e-a8a945513bfd.png)
## Guest User

Guest functionality is not currently impacted since guest users can only focus on portlets on their layout (UP-4041 will fix this).  However by commenting out the wrapping of the layout manager with the ImmutableUserLayoutManager (line 153 in UserInstanceManagerImpl.java) for guest, you can see what guest user's will eventually see as illustrated below for a portlet not on their layout when UP-4041 is resolved.

![guest user portlet not on layout - new](https://cloud.githubusercontent.com/assets/1479823/5322030/8f324752-7c7e-11e4-9599-e9bea584e3c2.png)
## Universality

The corresponding changes were made to Universality since they were not terribly difficult or time consuming.    My intent is not to make this feature (or more to the point the full UP-4041 implementation) flawless in Universality.  I don't see investment in the Universality theme at this point as particularly compelling with uPortal 4.1+.  Respondr is sufficiently superior that the community would need to vocally speak up to warrant the effort.  

Universality had decided for a focused transient portlet to create an URL to return to the normal dashboard view (display 1st tab) for the 'Return to dashboard' link.  I left it that way since it was such already defined to do that.  However I don't think that is necessarily the right user interaction (e.g. doesn't work for UP-3553 use case) so I did not implement it that way for Respondr.

![auth user portlet not on layout - universality](https://cloud.githubusercontent.com/assets/1479823/5322218/ac131a5c-7c80-11e4-85b9-2e61a7afb9d8.png)
