### PR TITLE
UP-4338 : Do not make profile selections by guest user sticky.

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/layout/profile/StickyProfileMapperImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/layout/profile/StickyProfileMapperImpl.java
@@ -98,6 +98,13 @@ public class StickyProfileMapperImpl
 
             final String userName = event.getPerson().getUserName();
 
+            if (event.getPerson().isGuest()) {
+                logger.warn("Ignoring a profile selection event fired by guest user. "
+                    + "Should the Guest user be firing profile selections in your uPortal "
+                    + "implementation?  Likely not.");
+                return;
+            }
+
             if (identitySwapperManager.isImpersonating(event.getRequest())) {
                 logger.debug("Ignoring selection of profile by key {} in the context of user {} because impersonated.",
                         event.getRequestedProfileKey(), userName);

--- a/uportal-war/src/test/java/org/jasig/portal/layout/profile/StickyProfileMapperImplTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/layout/profile/StickyProfileMapperImplTest.java
@@ -39,6 +39,8 @@ public class StickyProfileMapperImplTest {
 
     @Mock IPerson person;
 
+    @Mock IPerson guestPerson;
+
     @Mock HttpServletRequest request;
 
     @Mock IProfileSelectionRegistry registry;
@@ -65,6 +67,8 @@ public class StickyProfileMapperImplTest {
         stickyMapper.setProfileKeyForNoSelection("default");
 
         when(person.getUserName()).thenReturn("bobby");
+
+        when(guestPerson.isGuest()).thenReturn(true);
     }
 
     /**
@@ -123,6 +127,20 @@ public class StickyProfileMapperImplTest {
         // might have done weird unexpected things to the registry.
         verifyNoMoreInteractions(registry);
 
+    }
+
+    /**
+     * Test that does not store selections by guest user to registry.
+     */
+    @Test
+    public void testIngoresGuestUserProfileSelections() {
+
+        final ProfileSelectionEvent selectionEvent =
+            new ProfileSelectionEvent(this, "validKey1", guestPerson, request);
+
+        stickyMapper.onApplicationEvent(selectionEvent);
+
+        verifyZeroInteractions(registry);
     }
 
     /**


### PR DESCRIPTION
Fixes a bug ( [UP-4338](https://issues.jasig.org/browse/UP-4338) ) in the Sticky Profiles feature, preventing making guest user profile selections sticky.
