### PR TITLE
UP-4346 : Unit test that respondr.xsl compiles.

### DIFF
--- a/uportal-war/src/test/java/org/jasig/portal/rendering/xslt/PipelineStylesheetTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/rendering/xslt/PipelineStylesheetTest.java
@@ -67,6 +67,11 @@ public class PipelineStylesheetTest {
     public void testThemeMuniversalityCompile() throws Exception {
         this.testXslCompile("/layout/theme/muniversality/muniversality.xsl");
     }
+
+    @Test
+    public void testThemeRespondrCompile() throws Exception {
+        this.testXslCompile("/layout/theme/respondr/respondr.xsl");
+    }
     
     private void testXslCompile(String file) throws Exception {
         final Resource resource = new ClassPathResource(file);


### PR DESCRIPTION
Adds Respondr participation in the JUnit test that verifies XSLT compilation.

(I locally tested that if the XSLT can't compile due to mangling, the test does fail, so the test is at least superficially useful. Nonetheless it seems to run surprisingly very fast.)
