### PR TITLE
UP-4042 Guest was challenged for auth for portlet on its layout

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/url/UrlCanonicalizingFilter.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/UrlCanonicalizingFilter.java
@@ -113,7 +113,8 @@ public class UrlCanonicalizingFilter extends OncePerRequestFilter {
 
                     IPerson person = personManager.getPerson(request);
                     if (/* #1 */ person.isGuest()
-                            && /* #2 */ urlSyntaxProvider.doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(requestURI, canonicalUri)
+                            && /* #2 */ urlSyntaxProvider.doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
+                                                  requestURI, canonicalUri)
                             && /* #3 */ loginRefUrlEncoder != null) {
                         encodedTargetUrl = loginRefUrlEncoder.encodeLoginAndRefUrl(request);
                     }
@@ -125,12 +126,14 @@ public class UrlCanonicalizingFilter extends OncePerRequestFilter {
                     }
 
                     response.sendRedirect(encodedTargetUrl);
-                    logger.debug("Redirecting from {} to canonicalized URL {}, redirect {}", new Object[] {requestURI, canonicalUri, redirectCount});
+                    logger.debug("Redirecting from {} to canonicalized URL {}, redirect {}",
+                            requestURI, canonicalUri, redirectCount);
                     return;
                 }
 
                 this.clearRedirectCount(request, response);
-                logger.debug("Not redirecting from {} to canonicalized URL {} due to limit of {} redirects", new Object[] {requestURI, canonicalUri, redirectCount});
+                logger.debug("Not redirecting from {} to canonicalized URL {} due to limit of {} redirects",
+                        requestURI, canonicalUri, redirectCount);
             } else {
                 logger.trace("Requested URI {} is the canonical URL {}, " +
                         "so no (further?) redirect is necessary (after {} redirects).",

--- a/uportal-war/src/main/java/org/jasig/portal/url/UrlSyntaxProviderImpl.java
+++ b/uportal-war/src/main/java/org/jasig/portal/url/UrlSyntaxProviderImpl.java
@@ -761,7 +761,7 @@ public class UrlSyntaxProviderImpl implements IUrlSyntaxProvider {
     }
 
     /**
-     * If the targetedPortletWindowId is not null {@link #getPortletRequestInfo(IPortalRequestInfo, Map, IPortletWindowId)} is called and that
+     * If the targetedPortletWindowId is not null {@link IPortalRequestInfo#getPortletRequestInfo(IPortletWindowId)} is called and that
      * value is returned. If targetedPortletWindowId is null targetedPortletRequestInfo is returned.
      */
     protected PortletRequestInfoImpl getTargetedPortletRequestInfo(
@@ -1248,9 +1248,9 @@ public class UrlSyntaxProviderImpl implements IUrlSyntaxProvider {
         final ContentTuple canonicalTuple = ContentTuple.parse(canonicalPath);
 
         /*
-         * At this point they must be the same
+         * Return true if they are approximately/functionally equivalent.
          */
-        return !canonicalTuple.equals(requestTuple);
+        return !canonicalTuple.equalsIgnoringNullFolderDifferences(requestTuple);
 
     }
 
@@ -1300,26 +1300,42 @@ public class UrlSyntaxProviderImpl implements IUrlSyntaxProvider {
             return result;
         }
 
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
+        /**
+         * Compares two tuples for equality ignoring null folder differences.  A path such as
+         * /uPortal/p/uportal-links/max which doesn't specify a folder should be considered equal to a
+         * canonical path such as /uPortal/f/welcome/p/uportal-links.u32l1n12/max/render.uP
+         * which is targeting the same portlet but happens to specify the folder the portlet is on.
+         *
+         * @param obj <code>ContentTuple</code> to compare to
+         * @return true if the <code>ContentTuple's</code> are functionally equal ignoring one folder being null
+         */
+        public boolean equalsIgnoringNullFolderDifferences(Object obj) {
+            if (this == obj) {
                 return true;
-            if (obj == null)
+            }
+            if (obj == null) {
                 return false;
-            if (getClass() != obj.getClass())
+            }
+            if (getClass() != obj.getClass()) {
                 return false;
+            }
             ContentTuple other = (ContentTuple) obj;
-            if (folder == null) {
-                if (other.folder != null)
-                    return false;
-            } else if (!folder.equals(other.folder))
-                return false;
+
+            // If the portlets are not the same, return false.
             if (portlet == null) {
-                if (other.portlet != null)
+                if (other.portlet != null) {
                     return false;
-            } else if (!portlet.equals(other.portlet))
+                }
+            } else if (!portlet.equals(other.portlet)) {
                 return false;
-            return true;
+            }
+
+            // If only one of the folders is null, return true.  Otherwise if the folders are not the same,
+            // return false.
+            if (folder == null && other.folder != null || folder != null && other.folder == null) {
+                return true;
+            }
+            return folder.equals(other.folder);
         }
 
     }

--- a/uportal-war/src/test/java/org/jasig/portal/url/UrlSyntaxProviderImplTest.java
+++ b/uportal-war/src/test/java/org/jasig/portal/url/UrlSyntaxProviderImplTest.java
@@ -22,11 +22,6 @@
  */
 package org.jasig.portal.url;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.when;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -36,6 +31,9 @@ import javax.portlet.PortletMode;
 import javax.portlet.ResourceURL;
 import javax.portlet.WindowState;
 
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.jasig.portal.IUserPreferencesManager;
 import org.jasig.portal.layout.IUserLayout;
 import org.jasig.portal.layout.IUserLayoutManager;
@@ -58,9 +56,12 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.mock.web.MockHttpServletRequest;
 
-import com.google.common.base.Function;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 /**
  * Test harness for {@link UrlSyntaxProviderImpl}.
@@ -946,4 +947,64 @@ public class UrlSyntaxProviderImplTest {
         assertNotNull(portletRequestInfoMap);
         assertEquals(0, portletRequestInfoMap.size());
     }
+
+    @Test
+    public void testDoesRequestPathReferToSpecificAndDifferentContentVsCanonicalPathSameUrl() {
+        assertFalse("identical paths should be equal",
+                this.urlSyntaxProvider.doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
+                        "/uPortal/f/welcome/p/uportal-links.u32l1n12/max/render.uP",
+                        "/uPortal/f/welcome/p/uportal-links.u32l1n12/max/render.uP"));
+    }
+
+    @Test
+    public void testDoesRequestPathReferToSpecificAndDifferentContentVsCanonicalPathSamePrimaryUrl() {
+        assertFalse("functionally identical paths should be equal",
+                this.urlSyntaxProvider.doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
+                        "/uPortal/f/welcome/p/uportal-links/max",
+                        "/uPortal/f/welcome/p/uportal-links.u32l1n12/max/render.uP"));
+    }
+
+    @Test
+    public void testDoesRequestPathReferToSpecificAndDifferentContentVsCanonicalPathSamePortletNoFolder() {
+        assertFalse("path without folder specified should be equal",
+                this.urlSyntaxProvider.doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
+                        "/uPortal/p/uportal-links/max",
+                        "/uPortal/f/welcome/p/uportal-links.u32l1n12/max/render.uP"));
+    }
+
+    @Test
+    public void testDoesRequestPathReferToSpecificAndDifferentContentVsCanonicalPathDifferentFolder() {
+        assertTrue("path with different folder should not be equal",
+                this.urlSyntaxProvider.doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
+                        "/uPortal/f/other/p/uportal-links/max",
+                        "/uPortal/f/welcome/p/uportal-links.u32l1n12/max/render.uP"));
+    }
+
+    // Verifies ignores the state and url type.  Assumption is canonical path would have been properly derived
+    // from 1st path string so don't need to concern ourselves with the defaulting mechanism being correct in
+    // this test method.
+    @Test
+    public void testDoesRequestPathReferToSpecificAndDifferentContentVsCanonicalPathNoStateOrType() {
+        assertFalse("functionally identical paths no state (matching defaults) should be equal",
+                this.urlSyntaxProvider.doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
+                        "/uPortal/f/welcome/p/uportal-links",
+                        "/uPortal/f/welcome/p/uportal-links.u32l1n12/max/render.uP"));
+    }
+
+    @Test
+    public void testDoesRequestPathReferToSpecificAndDifferentContentVsCanonicalPathDifferentFolderAndPortlet() {
+        assertTrue("path with different folder and portlet should not be equal",
+                this.urlSyntaxProvider.doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
+                        "/uPortal/f/other/p/other/max",
+                        "/uPortal/f/welcome/p/uportal-links.u32l1n12/max/render.uP"));
+    }
+
+    @Test
+    public void testDoesRequestPathReferToSpecificAndDifferentContentVsCanonicalPathDifferentPortlet() {
+        assertTrue("path with different portlet should not be equal",
+                this.urlSyntaxProvider.doesRequestPathReferToSpecificAndDifferentContentVsCanonicalPath(
+                        "/uPortal/f/welcome/p/other/max",
+                        "/uPortal/f/welcome/p/uportal-links.u32l1n12/max/render.uP"));
+    }
+
 }


### PR DESCRIPTION
https://issues.jasig.org/browse/UP-4042

Guest URL such as http://localhost:8080/uPortal/p/uportal-links for portlet on guest's layout without specifying the folder param forced authentication.  With this change URL can be http://localhost:8080/uPortal/p/uportal-links or http://localhost:8080/uPortal/f/welcome/p/uportal-links and the portlet will be displayed without authentication.
