### PR TITLE
UP-4327 MarketplacePortletDefinition toString()

### DIFF
--- a/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/MarketplacePortletDefinition.java
+++ b/uportal-war/src/main/java/org/jasig/portal/portlet/marketplace/MarketplacePortletDefinition.java
@@ -192,8 +192,9 @@ public class MarketplacePortletDefinition implements IPortletDefinition{
 
     /**
      * Initialize related portlets.
-     * This must be called lazily so that MarketplacePortletDefinitions instantiated as related portlets off of a
-     * MarketplacePortletDefinition do not always intantiate their related MarketplacePortletDefinitions, ad infinitem.
+     * This must be called lazily so that MarketplacePortletDefinitions instantiated as related
+     * portlets off of a MarketplacePortletDefinition do not always instantiate their related
+     * MarketplacePortletDefinitions, ad infinitem.
      */
     private void initRelatedPortlets(){
         final Set<MarketplacePortletDefinition> allRelatedPortlets = new HashSet<>();


### PR DESCRIPTION
Adds `toString()` on `MarketplacePortletDefinition` for improved loggability ( [UP-4327](https://issues.jasig.org/browse/UP-4327) ).

Adds pro-forma JavaDoc on `MarketplacePortletDefinition` type.
