### PR TITLE
UP-4352 Updating PostgreSQL dependency in uportal-db

### DIFF
--- a/uportal-db/pom.xml
+++ b/uportal-db/pom.xml
@@ -35,7 +35,7 @@
          +-->
 	    <!--
 	    <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
 	        <artifactId>postgresql</artifactId>
 	        <version>${postgres.version}</version>
 	        <scope>compile</scope>


### PR DESCRIPTION
Updating dependency for PostgreSQL to have group "org.postgresql" instead of just "postgresql" this is the group where new artifacts for PostgreSQL driver (v9.2+) are being stored.
