### PR TITLE
[WIP] Issue #1409:  [WIP] support portal.allServerNames property in a safe way

### DIFF
--- a/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java
+++ b/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java
@@ -28,13 +28,12 @@ import org.springframework.mock.web.MockHttpServletRequest;
 public class CasLoginRefUrlEncoderTest {
 
     CasLoginRefUrlEncoder encoder;
-    MockHttpServletRequest request;
 
     @Before
     public void setUp() throws UnsupportedEncodingException {
         encoder = new CasLoginRefUrlEncoder();
         encoder.setCasLoginUrl(
-                "https://cas:80/cas/login?service=_CURRENT_SERVER_NAME_/uPortal/Login");
+                "https://cas:80/cas/login?service=https://testhost:8080/uPortal/Login");
         UrlMultiServerNameCustomizer urlCustomizer = new UrlMultiServerNameCustomizer();
         urlCustomizer.setAllServerNames(Sets.newHashSet("myhost:8080", "theirhost:8443"));
         List<IAuthUrlCustomizer> customizers = new ArrayList<>();
@@ -42,37 +41,37 @@ public class CasLoginRefUrlEncoderTest {
         UrlAuthCustomizerRegistry registry = new UrlAuthCustomizerRegistry();
         registry.setRegistry(customizers);
         encoder.setUrlCustomizer(registry);
-        request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
-        request.setCharacterEncoding("UTF-8");
-        request.setServerName("myhost");
-        request.setServerPort(8080);
-        request.addHeader("Host", "myhost:8080");
     }
 
     @Test
     public void testSimpleDestination() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
+        request.setCharacterEncoding("UTF-8");
+        request.setServerName("myhost");
+        request.setServerPort(8080);
+        request.addHeader("Host", "myhost:8080");
         assertEquals(
-                "https://cas:80/cas/login?service=myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname",
+                "https://cas:80/cas/login?service=https://myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname",
                 encoder.encodeLoginAndRefUrl(request));
     }
 
     @Test
     public void testWithParam() throws Exception {
-        request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
         request.setQueryString("pP_announcementId=1834");
         request.setCharacterEncoding("UTF-8");
         assertEquals(
-                "https://cas:80/cas/login?service=myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname%253FpP_announcementId%253D1834",
+                "https://cas:80/cas/login?service=https://myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname%253FpP_announcementId%253D1834",
                 encoder.encodeLoginAndRefUrl(request));
     }
 
     @Test
     public void testWithTwoParams() throws Exception {
-        request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "http://myhost:8080/uPortal/p/fname");
         request.setQueryString("pP_action=displayFullAnnouncement&pP_announcementId=1834");
         request.setCharacterEncoding("UTF-8");
         assertEquals(
-                "https://cas:80/cas/login?service=myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname%253FpP_action%253DdisplayFullAnnouncement%2526pP_announcementId%253D1834",
+                "https://cas:80/cas/login?service=https://myhost:8080/uPortal/Login%3FrefUrl%3Dhttp%3A%2F%2Fmyhost%3A8080%2FuPortal%2Fp%2Ffname%253FpP_action%253DdisplayFullAnnouncement%2526pP_announcementId%253D1834",
                 encoder.encodeLoginAndRefUrl(request));
     }
 }

--- a/uPortal-url/src/main/java/org/apereo/portal/url/UrlMultiServerNameCustomizer.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/UrlMultiServerNameCustomizer.java
@@ -1,23 +1,30 @@
 package org.apereo.portal.url;
 
 import com.google.common.collect.Sets;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Required;
 import org.springframework.util.Assert;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /** Customizer to replace a text by a serverName. */
 public class UrlMultiServerNameCustomizer implements IAuthUrlCustomizer {
+
+    private static final String LOGIN_URL_QUERYSTRING_PARAMETER = "service";
+    private static final String LOGOUT_REDIRECT_QUERYSTRING_PARAMETER = "url";
 
     /** Logger. */
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private Set<String> allServerNames = new HashSet<>();
-
-    private String serverNameTextReplacement = "_CURRENT_SERVER_NAME_";
 
     @Required
     public void setAllServerNames(final Set<String> serverNames) {
@@ -25,31 +32,97 @@ public class UrlMultiServerNameCustomizer implements IAuthUrlCustomizer {
         Assert.notEmpty(this.allServerNames, "The attribute serverNames should not be empty");
     }
 
-    public void setServerNameTextReplacement(final String serverNameTextReplacement) {
-        Assert.hasText(
-                serverNameTextReplacement,
-                "The serverNameTextReplacement attribute should not be empty");
-        this.serverNameTextReplacement = serverNameTextReplacement;
-    }
-
     public boolean supports(final HttpServletRequest request, final String url) {
-        return url != null && url.contains(serverNameTextReplacement);
+        if (StringUtils.isBlank(url)) {
+            return false;
+        }
+        final MultiValueMap<String, String> parameters =
+                UriComponentsBuilder.fromUriString(url).build().getQueryParams();
+        return parameters.containsKey(LOGIN_URL_QUERYSTRING_PARAMETER)
+                || parameters.containsKey(LOGOUT_REDIRECT_QUERYSTRING_PARAMETER);
     }
 
     public String customizeUrl(final HttpServletRequest request, final String url) {
-        if (url != null && !url.isEmpty() && supports(request, url)) {
-            final String updateUrl =
-                    url.replaceFirst(serverNameTextReplacement, findMatchingServerName(request));
+        if (supports(request, url)) {
 
-            if (logger.isDebugEnabled()) {
-                logger.debug("Modifying Url Domain from [{}] to [{}]", url, updateUrl);
+            final String matchingServerName = findMatchingServerName(request);
+            if (StringUtils.isNotBlank(matchingServerName)) {
+
+                final String matchingHostnamePart =
+                        matchingServerName.contains(":")
+                                ? matchingServerName.split(":")[0]
+                                : matchingServerName;
+                final String matchingPortPart =
+                        matchingServerName.contains(":") ? matchingServerName.split(":")[1] : null;
+
+                final UriComponentsBuilder uriComponentsBuilder =
+                        UriComponentsBuilder.fromUriString(url);
+                final MultiValueMap<String, String> parameters =
+                        uriComponentsBuilder.build().getQueryParams();
+
+                try {
+
+                    // Replace LOGIN_URL_QUERYSTRING_PARAMETER
+                    if (parameters.containsKey(LOGIN_URL_QUERYSTRING_PARAMETER)) {
+                        final List<String> originalList =
+                                parameters.get(LOGIN_URL_QUERYSTRING_PARAMETER);
+                        final List<String> copyList = new ArrayList<>();
+                        for (String s : originalList) {
+                            final UriComponents originalUri =
+                                    UriComponentsBuilder.fromUriString(s).build();
+                            final UriComponentsBuilder copyUriBuilder =
+                                    UriComponentsBuilder.newInstance()
+                                            .scheme(originalUri.getScheme())
+                                            .host(matchingHostnamePart)
+                                            .path(originalUri.getPath())
+                                            .query(originalUri.getQuery());
+                            if (StringUtils.isNotBlank(matchingPortPart)) {
+                                copyUriBuilder.port(matchingPortPart);
+                            }
+                            copyList.add(copyUriBuilder.toUriString());
+                        }
+                        uriComponentsBuilder.replaceQueryParam(
+                                LOGIN_URL_QUERYSTRING_PARAMETER, copyList.toArray());
+                    }
+
+                    // Replace LOGIN_URL_QUERYSTRING_PARAMETER
+                    if (parameters.containsKey(LOGOUT_REDIRECT_QUERYSTRING_PARAMETER)) {
+                        final List<String> originalList =
+                                parameters.get(LOGOUT_REDIRECT_QUERYSTRING_PARAMETER);
+                        final List<String> copyList = new ArrayList<>();
+                        for (String s : originalList) {
+                            final UriComponents originalUri =
+                                    UriComponentsBuilder.fromUriString(s).build();
+                            final UriComponentsBuilder copyUriBuilder =
+                                    UriComponentsBuilder.newInstance()
+                                            .scheme(originalUri.getScheme())
+                                            .host(matchingHostnamePart)
+                                            .path(originalUri.getPath())
+                                            .query(originalUri.getQuery());
+                            if (StringUtils.isNotBlank(matchingPortPart)) {
+                                copyUriBuilder.port(matchingPortPart);
+                            }
+                            copyList.add(copyUriBuilder.toUriString());
+                        }
+                        uriComponentsBuilder.replaceQueryParam(
+                                LOGOUT_REDIRECT_QUERYSTRING_PARAMETER, copyList.toArray());
+                    }
+
+                } catch (Exception e) {
+                    logger.warn("Failed to customize the specified URL:  {}", url);
+                    throw new RuntimeException(e);
+                }
+
+                final String rslt = uriComponentsBuilder.build().toUriString();
+                logger.debug("Customizing URL from [{}] to [{}]", url, rslt);
+                return rslt;
             }
-            return updateUrl;
         }
-        return url;
+
+        return url; // No change
     }
 
-    protected String findMatchingServerName(final HttpServletRequest request) {
+    private String findMatchingServerName(final HttpServletRequest request) {
         if (request != null) {
             final String comparisonHost = request.getHeader("Host");
             if (comparisonHost != null && !comparisonHost.isEmpty()) {
@@ -61,6 +134,6 @@ public class UrlMultiServerNameCustomizer implements IAuthUrlCustomizer {
             }
         }
 
-        return this.allServerNames.iterator().next();
+        return null;
     }
 }

--- a/uPortal-webapp/src/main/resources/properties/security.properties
+++ b/uPortal-webapp/src/main/resources/properties/security.properties
@@ -35,7 +35,7 @@
 portal.protocol=http
 portal.server=localhost:8080
 portal.context=/uPortal
-portal.protocol.server.context=${portal.protocol}://_CURRENT_SERVER_NAME_${portal.context}
+portal.protocol.server.context=${portal.protocol}://${portal.server}${portal.context}
 portal.login.url=${portal.protocol.server.context}/Login
 
 # Needed for proxy-cas in load-balanced system like Apache to return the


### PR DESCRIPTION
Resolves #1409 

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

I could really use your help on this one @jgribonvald.  ;-)

This PR is another take on issue #1409 and pull request #1410.

The key difference in this PR -- and the essence of the issue, I think -- is that I feel we should avoid having the token `_CURRENT_SERVER_NAME_` (or any such token) inside a Spring-managed property.

The token replacement tech is 100% custom.  Spring doesn't know about it, so it faithfully inserts the original property value (incl. the token) everywhere the property is referenced.

All of the following have multiple uses in the portal:
  - `portal.protocol.server.context`
  - `portal.login.url`
  - `org.apereo.portal.channels.CLogin.CasLoginUrl`

Putting `_CURRENT_SERVER_NAME_` into any of them (inside security.properties) will result in the unprocessed token getting used somewhere in the portal.

This PR updates the `UrlMultiServerNameCustomizer`, attempting to parse the URL being processed into its bits (`host`, `port`, `path`, _etc._) and replace some of those bits in the intended way .

It's not entirely working ATM.  All the tests (3) are broken (`CasLoginRefUrlEncoderTest`).  One seems to be only an encoding issue;  the other two don't get the `hostname` they expect.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
