### PR TITLE
GH-1858 - Don't show "direct url" in a form input field.

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
@@ -401,7 +401,7 @@
                         <h4 class="modal-title"><xsl:value-of select="upMsg:getMessage('direct.url', $USER_LANG)"/></h4>
                     </div>
                     <div class="modal-body">
-                        <p id="direct-url-display"></p>
+                        <p id="direct-url-display" tabindex="0"></p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal"><xsl:value-of select="upMsg:getMessage('close', $USER_LANG)"/></button>

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/regions.xsl
@@ -401,11 +401,7 @@
                         <h4 class="modal-title"><xsl:value-of select="upMsg:getMessage('direct.url', $USER_LANG)"/></h4>
                     </div>
                     <div class="modal-body">
-                        <form>
-                            <div class="form-group">
-                                <input type="text" class="form-control" id="direct-url-display"/>
-                            </div>
-                        </form>
+                        <p id="direct-url-display"></p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal"><xsl:value-of select="upMsg:getMessage('close', $USER_LANG)"/></button>
@@ -419,7 +415,7 @@
                 $('#direct-url-modal').on('show.bs.modal', function (event) {
                     var widget = $(event.relatedTarget); // Widget that triggered the modal
                     var dUrl = widget.data('direct-url'); // Extract info from data-* attributes
-                    $('#direct-url-display').val(dUrl);
+                    $('#direct-url-display').text(dUrl);
                 });
             });
         </script>


### PR DESCRIPTION
-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

Show the portlet's direct url as read-only text rather than putting it in a form field that shouldn't be edited.

https://github.com/Jasig/uPortal/issues/1858