### PR TITLE
feat: CAS URL customizing from Portal Request

### DIFF
--- a/uPortal-url/build.gradle
+++ b/uPortal-url/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compile project(':uPortal-security:uPortal-security-core')
 
     compileOnly "org.apache.portals.pluto:pluto-container-api:${plutoVersion}"
+    compileOnly "org.apache.portals.pluto:pluto-container:${plutoVersion}"
     compileOnly "${portletApiDependency}"
     compileOnly "${servletApiDependency}"
 }

--- a/uPortal-url/src/main/java/org/apereo/portal/url/UrlCasParamAppenderFromPortalRequestCustomizer.java
+++ b/uPortal-url/src/main/java/org/apereo/portal/url/UrlCasParamAppenderFromPortalRequestCustomizer.java
@@ -1,0 +1,84 @@
+package org.apereo.portal.url;
+
+import javax.servlet.http.HttpServletRequest;
+import org.apache.pluto.container.impl.HttpServletPortletRequestWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.Assert;
+
+/** Customizer to append a parameter depending on PortalRequest. */
+public class UrlCasParamAppenderFromPortalRequestCustomizer
+        implements IAuthUrlCustomizer, InitializingBean {
+
+    /** Logger. */
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /** Regex condition to apply Customization. */
+    private String applyCondition = ".*\\?param=xyz.*";
+
+    /** Param name with equal and value to append to url. */
+    private String paramToAppend;
+
+    public void setApplyCondition(final String applyCondition) {
+        this.applyCondition = applyCondition;
+    }
+
+    public void setParamToAppend(final String paramToAppend) {
+        this.paramToAppend = paramToAppend;
+    }
+
+    @Override
+    public boolean supports(final HttpServletRequest request, final String url) {
+        final String requestUrl = getFullURL(request);
+        if (requestUrl == null) {
+            logger.warn("Try to customize a cas url from a null HttpServletRequest !");
+        }
+        return url != null && requestUrl != null && requestUrl.matches(applyCondition);
+    }
+
+    public String customizeUrl(final HttpServletRequest request, final String url) {
+        if (url != null && !url.isEmpty() && supports(request, url)) {
+            final String updatedUrl = url + "&" + paramToAppend;
+
+            if (logger.isDebugEnabled()) {
+                logger.debug(String.format("Modifying CAS Url from [%s] to [%s]", url, updatedUrl));
+            }
+            return updatedUrl;
+        }
+        return url;
+    }
+
+    public static String getFullURL(HttpServletRequest request) {
+        if (request == null) return null;
+        StringBuilder requestURL;
+        HttpServletRequest portalRequest = request;
+
+        // Usefull in case of request passed from the xslt/portlet context, we don't have the portal
+        // request passed
+        if (request instanceof HttpServletPortletRequestWrapper) {
+            portalRequest =
+                    (HttpServletRequest)
+                            request.getAttribute(
+                                    PortalHttpServletRequestWrapper
+                                            .ATTRIBUTE__HTTP_SERVLET_REQUEST);
+        }
+
+        if (portalRequest == null || portalRequest.getRequestURL() == null) return null;
+
+        requestURL = new StringBuilder(portalRequest.getRequestURL().toString());
+
+        final String queryString = portalRequest.getQueryString();
+
+        if (queryString != null) {
+            return requestURL.append('?').append(queryString).toString();
+        }
+        return requestURL.toString();
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        Assert.hasText(this.applyCondition, "No applyCondition supplied !");
+        Assert.hasText(this.paramToAppend, "No paramToAppend supplied !");
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->

This new customizer permit to pass params from a portalRequest to the CAS server (usefull when using a WAYF on CAS). All other customizers are doing the job only from CAS URL, this one introduce the possibility from a portal request (usefull when intiated from an IDP).

As example this customizer permit to request the portal from a such request: `https://my.portal.edu/uPortal?idpSelected=IDPid` and the customizer will customize the CAS with service url with a new parameter that permit to preselect an IDP from the WAYF page. It permits to bypass a WAYF by preselecting an IDP.

<!-- Reference Links -->
CAS url Customizing was introduced from #1320

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
