### PR TITLE
fix: re-add up-portlet-title token to fix dynamic titles

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/content.xsl
@@ -336,7 +336,7 @@
         <!-- Reference anchor for page focus on refresh and link to focused view of channel. -->
         <xsl:element name="a">
           <xsl:attribute name="id"><xsl:value-of select="@ID"/></xsl:attribute>
-          <xsl:attribute name="title"><xsl:value-of select="@title"/></xsl:attribute>
+          <xsl:attribute name="title">{up-portlet-title(<xsl:value-of select="@ID"/>)}</xsl:attribute>
           <xsl:choose>
             <xsl:when test="parameter[@name='alternativeMaximizedLink'] and string-length(parameter[@name='alternativeMaximizedLink']/@value) > 0">
               <xsl:attribute name="href"><xsl:value-of select="parameter[@name='alternativeMaximizedLink']/@value" /></xsl:attribute>
@@ -358,7 +358,7 @@
               <xsl:attribute name="href"><xsl:value-of select="$portletMaxUrl" /></xsl:attribute>
             </xsl:otherwise>
           </xsl:choose>
-          <xsl:value-of select="@title"/>
+          {up-portlet-title(<xsl:value-of select="@ID"/>)}
         </xsl:element>
       </h2>
       <xsl:call-template name="controls">


### PR DESCRIPTION
Resolves #2285

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Re-added `{up-portlet-title(xxx)}` to content layout used to support dynamic portlet titles.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
