### PR TITLE
fix: adding a tab or maximizing a portlet now stick to the tabgroup

### DIFF
--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -124,7 +124,7 @@
                                 </xsl:variable>
                                 <li class="{$TABGROUP_ACTIVE} portal-navigation-tabgroup fl-tabs-active list-group-item portal-navigation">
                                     <a href="{$TABGROUP_URL}" title="{.}" class="portal-tabGroup-link portal-navigation-link">
-                                        <span id ="{$ACTIVE_TABGROUP}" class="portal-tabGroup-label portal-navigation-label"><xsl:value-of select="$TABGROUP_LABEL"/></span></a>
+                                        <span id="{$ACTIVE_TABGROUP}" class="portal-tabGroup-label portal-navigation-label"><xsl:value-of select="$TABGROUP_LABEL"/></span></a>
                                 </li>
                             </xsl:for-each>
                         </ul>

--- a/uPortal-webapp/src/main/resources/layout/theme/respondr/navigation.xsl
+++ b/uPortal-webapp/src/main/resources/layout/theme/respondr/navigation.xsl
@@ -100,6 +100,13 @@
                                         <xsl:otherwise></xsl:otherwise>
                                     </xsl:choose>
                                 </xsl:variable>
+                                <xsl:variable name="ACTIVE_TABGROUP">
+                                    <!-- used by tabManager.js for text -->
+                                    <xsl:choose>
+                                        <xsl:when test="/layout/navigation/tabGroupsList/@activeTabGroup=.">activeTabGroup</xsl:when>
+                                        <xsl:otherwise></xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:variable>
                                 <xsl:variable name="TABGROUP_LABEL">
                                     <xsl:choose>
                                         <xsl:when test="@name='DEFAULT_TABGROUP'"><xsl:value-of select="upMsg:getMessage('navigation.tabgroup.default', $USER_LANG)"/></xsl:when>
@@ -117,7 +124,7 @@
                                 </xsl:variable>
                                 <li class="{$TABGROUP_ACTIVE} portal-navigation-tabgroup fl-tabs-active list-group-item portal-navigation">
                                     <a href="{$TABGROUP_URL}" title="{.}" class="portal-tabGroup-link portal-navigation-link">
-                                        <span class="portal-tabGroup-label portal-navigation-label"><xsl:value-of select="$TABGROUP_LABEL"/></span></a>
+                                        <span id ="{$ACTIVE_TABGROUP}" class="portal-tabGroup-label portal-navigation-label"><xsl:value-of select="$TABGROUP_LABEL"/></span></a>
                                 </li>
                             </xsl:for-each>
                         </ul>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
When tabgroups were active, adding a new tab or maximizing a portlet would create a new "More" tabgroup rather than remain in the current tabgroup. The `tabManager.js` code supports tabgroups. It was looking for an ID that was not migrated to Respondr. This PR adds the needed ID.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
