### PR TITLE
fix: escape search param string

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchRest.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchRest.jsp
@@ -112,7 +112,7 @@
 
 <%-- API URL for fetching search results --%>
 <c:url value="/api/v5-0/portal/search" var="searchApiUrl">
-    <c:param name="q" value="${param.query}" />
+    <c:param name="q" value="${fn:escapeXml(param.query)}" />
     <c:forEach items="${renderRequest.preferences.map['RESTSearch.type']}" var="value">
         <c:param name="type" value="${value}" />
     </c:forEach>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Can add scripting in via search feature.

To reproduce:
1. Start uPortal
2. visit `http://localhost:8080/uPortal/p/search.ctf2/max/render.uP?pP_query=1234'+alert(5678)+'`

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
