### PR TITLE
Fix - add swagger endpoint to CSRF ignore list

### DIFF
--- a/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/csrf/PortalCsrfSecurityRequestMatcher.java
+++ b/uPortal-security/uPortal-security-core/src/main/java/org/apereo/portal/security/csrf/PortalCsrfSecurityRequestMatcher.java
@@ -44,8 +44,10 @@ public class PortalCsrfSecurityRequestMatcher implements RequestMatcher {
 
     private static final String API_PATTERN = "/api.*";
 
+    private static final String API_DOCS_PATTERN = "/api/swagger-ui.html";
+
     private static final String[] IGNORED_PATTERNS =
-            new String[] {LOGIN_PATTERN, LOGOUT_PATTERN, API_PATTERN};
+            new String[] {LOGIN_PATTERN, LOGOUT_PATTERN, API_PATTERN, API_DOCS_PATTERN};
 
     private final Set<RequestMatcher> ignoredMatchers = new HashSet<>();
 


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
uPortal was unable to launch the Swagger / openAPI docs due to a CSRF error. This PR adds the swagger context path / link to the CSRF exception list.
