### PR TITLE
uP 570 - Add workaround for missing doctype

### DIFF
--- a/uPortal-web/src/main/java/org/apereo/portal/rendering/DynamicRenderingPipeline.java
+++ b/uPortal-web/src/main/java/org/apereo/portal/rendering/DynamicRenderingPipeline.java
@@ -89,6 +89,11 @@ public class DynamicRenderingPipeline implements IPortalRenderingPipeline {
             }
 
             final String data = ((CharacterDataEvent) event).getData();
+            if (data.startsWith("<html ")) {
+                // Workaround for the Java 8 doctype issue -
+                // https://github.com/uPortal-Project/uPortal-start/issues/570
+                writer.print("<!DOCTYPE html SYSTEM \"EMPTY\">\n");
+            }
             writer.print(data);
             writer.flush();
             res.flushBuffer();


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
History in https://github.com/uPortal-Project/uPortal-start/issues/570

Adds the 'empty' doctype to html pages that does not start with the doctype.

The default XSL processor (Xalan) is still used.