### PR TITLE
feat(events): add ip address to raw login events

### DIFF
--- a/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/events/LoginEvent.java
+++ b/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/events/LoginEvent.java
@@ -26,17 +26,20 @@ import org.apache.commons.lang.Validate;
 
 /** @since 2.6 */
 public final class LoginEvent extends PortalEvent {
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     private final Set<String> groups;
 
     private final Map<String, List<String>> attributes;
+
+    private final String ipAddress;
 
     @SuppressWarnings("unused")
     private LoginEvent() {
         super();
         this.groups = Collections.emptySet();
         this.attributes = Collections.emptyMap();
+        this.ipAddress = "0.0.0.0";
     }
 
     LoginEvent(
@@ -55,6 +58,7 @@ public final class LoginEvent extends PortalEvent {
                     attributeEntry.getKey(), ImmutableList.copyOf(attributeEntry.getValue()));
         }
         this.attributes = attributesBuilder.build();
+        this.ipAddress = eventBuilder.getPortalRequest().getRemoteAddr();
     }
 
     /** @return The groups the user was in at login */
@@ -67,6 +71,11 @@ public final class LoginEvent extends PortalEvent {
         return this.attributes;
     }
 
+    /** @return The IP Address for the user */
+    public String getIpAddress() {
+        return this.ipAddress;
+    }
+
     /* (non-Javadoc)
      * @see java.lang.Object#toString()
      */
@@ -77,6 +86,7 @@ public final class LoginEvent extends PortalEvent {
                 + this.groups.size()
                 + ", attributes="
                 + this.attributes.size()
+                + ", ipAddress=MASKED"
                 + "]";
     }
 }

--- a/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/events/LoginEvent.java
+++ b/uPortal-utils/uPortal-utils-core/src/main/java/org/apereo/portal/events/LoginEvent.java
@@ -23,10 +23,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang.Validate;
+import org.springframework.beans.factory.annotation.Value;
 
 /** @since 2.6 */
 public final class LoginEvent extends PortalEvent {
     private static final long serialVersionUID = 2L;
+
+    @Value("${org.apereo.portal.events.LoginEvent.captureUserIpAddresses:false}")
+    private boolean captureUserIpAddresses;
 
     private final Set<String> groups;
 
@@ -58,7 +62,11 @@ public final class LoginEvent extends PortalEvent {
                     attributeEntry.getKey(), ImmutableList.copyOf(attributeEntry.getValue()));
         }
         this.attributes = attributesBuilder.build();
-        this.ipAddress = eventBuilder.getPortalRequest().getRemoteAddr();
+
+        this.ipAddress =
+                this.captureUserIpAddresses
+                        ? eventBuilder.getPortalRequest().getRemoteAddr()
+                        : "0.0.0.0";
     }
 
     /** @return The groups the user was in at login */
@@ -86,7 +94,7 @@ public final class LoginEvent extends PortalEvent {
                 + this.groups.size()
                 + ", attributes="
                 + this.attributes.size()
-                + ", ipAddress=MASKED"
+                + ", ipAddress=MASKED" // never log
                 + "]";
     }
 }

--- a/uPortal-webapp/src/main/resources/properties/portal.properties
+++ b/uPortal-webapp/src/main/resources/properties/portal.properties
@@ -295,6 +295,10 @@ org.apereo.portal.events.aggr.PortalEventProcessingManagerImpl.populateDimension
 org.apereo.portal.events.aggr.PortalEventProcessingManagerImpl.purgeEventSessionsPeriod=61700
 org.apereo.portal.events.aggr.PortalEventProcessingManagerImpl.purgeRawEventsPeriod=61300
 
+##
+## Configure Login Events (raw) to capture user IP addresses. This is not included in aggregation.
+## N.B. This raises privacy concerns and should only be enabled after very careful consideration.
+org.apereo.portal.events.LoginEvent.captureUserIpAddresses=false
 
 ################################################################################
 ##                                                                            ##


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] the [individual contributor license agreement][] is signed
-   [X] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [ ] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
An implementer is consuming raw events for analytics. They wish to capture user IP addresses for geolocation. This change adds user IP addresses to Login events.

Tests are not included given the triviality of the change (and some manual testing to confirm correct operation).

There is no documentation around event details.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
