### PR TITLE
Feat/analytics aggregator

### DIFF
--- a/uPortal-events/src/main/java/org/apereo/portal/events/aggr/analytics/AnalyticsEventAggregator.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/aggr/analytics/AnalyticsEventAggregator.java
@@ -1,0 +1,27 @@
+package org.apereo.portal.events.aggr.analytics;
+
+import org.apereo.portal.events.AnalyticsPortalEvent;
+import org.apereo.portal.events.PortalEvent;
+import org.apereo.portal.events.aggr.BasePortalEventAggregator;
+import org.apereo.portal.events.aggr.SimplePortalEventAggregator;
+import org.apereo.portal.events.aggr.session.EventSession;
+import org.apereo.portal.events.handlers.db.IPortalEventDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnalyticsEventAggregator extends BasePortalEventAggregator<PortalEvent>
+        implements SimplePortalEventAggregator<PortalEvent> {
+
+    @Autowired private IPortalEventDao store;
+
+    @Override
+    public boolean supports(Class<? extends PortalEvent> type) {
+        return AnalyticsPortalEvent.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public void aggregateEvent(PortalEvent e, EventSession eventSession) {
+        store.storeAnalyticsEvent(e);
+    }
+}

--- a/uPortal-events/src/main/java/org/apereo/portal/events/handlers/db/IPortalEventDao.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/handlers/db/IPortalEventDao.java
@@ -27,6 +27,8 @@ public interface IPortalEventDao {
 
     void storePortalEvents(Iterable<PortalEvent> portalEvents);
 
+    void storeAnalyticsEvent(PortalEvent portalEvent);
+
     /**
      * Gets all persisted events in the time range. To deal with memory and data access issues the
      * results are not returned but passed in order to the provided {@link FunctionWithoutResult}

--- a/uPortal-events/src/main/java/org/apereo/portal/events/handlers/db/JpaPortalEventStore.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/handlers/db/JpaPortalEventStore.java
@@ -185,6 +185,14 @@ public class JpaPortalEventStore extends BaseRawEventsJpaDao implements IPortalE
 
     @Override
     @RawEventsTransactional
+    public void storeAnalyticsEvent(PortalEvent portalEvent) {
+        final PersistentAnalyticsEvent persistentAnalyticsEvent =
+                this.wrapAnalyticsEvent(portalEvent);
+        this.getEntityManager().persist(persistentAnalyticsEvent);
+    }
+
+    @Override
+    @RawEventsTransactional
     public void storePortalEvents(PortalEvent... portalEvents) {
         for (final PortalEvent portalEvent : portalEvents) {
             try {
@@ -378,6 +386,11 @@ public class JpaPortalEventStore extends BaseRawEventsJpaDao implements IPortalE
     protected PersistentPortalEvent wrapPortalEvent(PortalEvent event) {
         final String portalEventData = this.toString(event);
         return new PersistentPortalEvent(event, portalEventData);
+    }
+
+    protected PersistentAnalyticsEvent wrapAnalyticsEvent(PortalEvent event) {
+        final String portalEventData = this.toString(event);
+        return new PersistentAnalyticsEvent(event, portalEventData);
     }
 
     protected <E extends PortalEvent> E toPortalEvent(final String eventData, Class<E> eventType) {

--- a/uPortal-events/src/main/java/org/apereo/portal/events/handlers/db/PersistentAnalyticsEvent.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/handlers/db/PersistentAnalyticsEvent.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.events.handlers.db;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Lob;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.TableGenerator;
+import org.apereo.portal.events.PortalEvent;
+import org.hibernate.annotations.Index;
+import org.hibernate.annotations.Type;
+import org.joda.time.DateTime;
+
+/** Persistent wrapper for storing portal events */
+@Entity
+@Table(name = "UP_ANALYTICS_EVENTS")
+@Inheritance(strategy = InheritanceType.JOINED)
+@SequenceGenerator(
+        name = "UP_ANALYTICS_EVENTS_GEN",
+        sequenceName = "UP_ANALYTICS_EVENTS_SEQ",
+        allocationSize = 1000)
+@TableGenerator(
+        name = "UP_ANALYTICS_EVENTS_GEN",
+        pkColumnValue = "UP_ANNALYTICS_EVENTS_PROP",
+        allocationSize = 1000)
+public class PersistentAnalyticsEvent implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(generator = "UP_ANALYTICS_EVENTS_GEN")
+    @Column(name = "EVENT_ID")
+    @SuppressWarnings("unused")
+    private final long id;
+
+    @Index(name = "IDX_UP_ANALYTICS_EVENTS_TIMESTAMP")
+    @Column(name = "TIMESTAMP", nullable = false, updatable = false)
+    @Type(type = "dateTime")
+    @SuppressWarnings("unused")
+    private final DateTime timestamp;
+
+    @Index(name = "IDX_UP_ANALYTICS_EVENTS_SERVER_ID")
+    @Column(name = "SERVER_ID", length = 200, nullable = false, updatable = false)
+    @SuppressWarnings("unused")
+    private final String serverId;
+
+    @Index(name = "IDX_UP_ANALYTICS_EVENTS_SESSION_ID")
+    @Column(name = "SESSION_ID", length = 500, nullable = false, updatable = false)
+    @SuppressWarnings("unused")
+    private final String eventSessionId;
+
+    @Index(name = "IDX_UP_ANALYTICS_EVENTS_USER_NAME")
+    @Column(name = "USER_NAME", length = 100, nullable = false, updatable = false)
+    @SuppressWarnings("unused")
+    private final String userName;
+
+    @Column(name = "EVENT_TYPE", length = 200, nullable = false, updatable = false)
+    @Type(type = "class")
+    private final Class<PortalEvent> eventType;
+
+    @Column(name = "EVENT_DATA", nullable = false, updatable = false, length = 10000)
+    @Lob
+    private final String eventData;
+
+    // TODO not needed
+    @Index(name = "IDX_UP_ANALYTICS_EVENTS_AGGREGATED")
+    @Column(name = "AGGREGATED")
+    private Boolean aggregated = false;
+
+    // TODO not needed
+    @Index(name = "IDX_UP_ANALYTICS_EVENTS_ERR_AGGR")
+    @Column(name = "ERROR_AGGR")
+    private Boolean errorAggregating = false;
+
+    /** no-arg needed by hibernate */
+    @SuppressWarnings("unused")
+    private PersistentAnalyticsEvent() {
+        this.id = -1;
+        this.eventData = null;
+        this.timestamp = null;
+        this.serverId = null;
+        this.eventSessionId = null;
+        this.userName = null;
+        this.eventType = null;
+    }
+
+    @SuppressWarnings("unchecked")
+    PersistentAnalyticsEvent(PortalEvent portalEvent, String eventData) {
+        this.id = -1;
+        this.eventData = eventData;
+        this.timestamp = new DateTime(portalEvent.getTimestamp());
+        this.serverId = portalEvent.getServerId();
+        this.eventSessionId = portalEvent.getEventSessionId();
+        this.userName = portalEvent.getUserName();
+        this.eventType = (Class<PortalEvent>) portalEvent.getClass();
+    }
+
+    public Class<PortalEvent> getEventType() {
+        return this.eventType;
+    }
+
+    /** @return the eventData */
+    public String getEventData() {
+        return this.eventData;
+    }
+
+    public boolean isAggregated() {
+        Boolean a = this.aggregated;
+        if (a == null) {
+            a = false;
+            this.aggregated = a;
+        }
+        return a;
+    }
+
+    void setAggregated(boolean aggregated) {
+        this.aggregated = aggregated;
+    }
+
+    public boolean isErrorAggregating() {
+        Boolean a = this.errorAggregating;
+        if (a == null) {
+            a = false;
+            this.errorAggregating = a;
+        }
+        return a;
+    }
+
+    void setErrorAggregating(boolean errorAggregating) {
+        this.errorAggregating = errorAggregating;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return this.eventData;
+    }
+}

--- a/uPortal-events/src/main/java/org/apereo/portal/events/handlers/db/PersistentAnalyticsEvent.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/events/handlers/db/PersistentAnalyticsEvent.java
@@ -80,16 +80,6 @@ public class PersistentAnalyticsEvent implements Serializable {
     @Lob
     private final String eventData;
 
-    // TODO not needed
-    @Index(name = "IDX_UP_ANALYTICS_EVENTS_AGGREGATED")
-    @Column(name = "AGGREGATED")
-    private Boolean aggregated = false;
-
-    // TODO not needed
-    @Index(name = "IDX_UP_ANALYTICS_EVENTS_ERR_AGGR")
-    @Column(name = "ERROR_AGGR")
-    private Boolean errorAggregating = false;
-
     /** no-arg needed by hibernate */
     @SuppressWarnings("unused")
     private PersistentAnalyticsEvent() {
@@ -120,32 +110,6 @@ public class PersistentAnalyticsEvent implements Serializable {
     /** @return the eventData */
     public String getEventData() {
         return this.eventData;
-    }
-
-    public boolean isAggregated() {
-        Boolean a = this.aggregated;
-        if (a == null) {
-            a = false;
-            this.aggregated = a;
-        }
-        return a;
-    }
-
-    void setAggregated(boolean aggregated) {
-        this.aggregated = aggregated;
-    }
-
-    public boolean isErrorAggregating() {
-        Boolean a = this.errorAggregating;
-        if (a == null) {
-            a = false;
-            this.errorAggregating = a;
-        }
-        return a;
-    }
-
-    void setErrorAggregating(boolean errorAggregating) {
-        this.errorAggregating = errorAggregating;
     }
 
     /* (non-Javadoc)

--- a/uPortal-events/src/test/java/org/apereo/portal/aggr/analytics/AnalyticsEventAggregatorTests.java
+++ b/uPortal-events/src/test/java/org/apereo/portal/aggr/analytics/AnalyticsEventAggregatorTests.java
@@ -1,0 +1,19 @@
+package org.apereo.portal.aggr.analytics;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.apereo.portal.events.AnalyticsPortalEvent;
+import org.apereo.portal.events.LoginEvent;
+import org.apereo.portal.events.aggr.analytics.AnalyticsEventAggregator;
+import org.junit.Test;
+
+public class AnalyticsEventAggregatorTests {
+
+    @Test
+    public void testSupports() {
+        AnalyticsEventAggregator aggr = new AnalyticsEventAggregator();
+        assertTrue(aggr.supports(AnalyticsPortalEvent.class));
+        assertFalse(aggr.supports(LoginEvent.class));
+    }
+}

--- a/uPortal-webapp/src/main/resources/properties/db/hibernate-raw-events.cfg.xml
+++ b/uPortal-webapp/src/main/resources/properties/db/hibernate-raw-events.cfg.xml
@@ -43,5 +43,6 @@
         <mapping resource="properties/db/global.hbm.xml"/>
         
         <mapping class="org.apereo.portal.events.handlers.db.PersistentPortalEvent"/>
+        <mapping class="org.apereo.portal.events.handlers.db.PersistentAnalyticsEvent"/>
     </session-factory>
 </hibernate-configuration>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x ] the [individual contributor license agreement][] is signed
-   [x ] commit message follows [commit guidelines][]
-   [x ] tests are included
-   [x ] documentation is changed or added
-   [ ] new security keys and comments added to `security.properties`
-   [ ] new general keys and comments added to `portal.properties`
-   [x ] any changes that impact configuration or the database DDL added to `CHANGES.md`
-   [ ] [message properties][] have been updated with new phrases
-   [ ] view conforms with [WCAG 2.0 AA][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
This change introduces a new Aggregator for the AnalyticsPortalEvent.  Before now, the AnalyticsPortalEvent, if present, would be ignored after being marked as aggregated.  Now, each AnalyticsPortalEvent that is received will be added to the UP_ANALYTICS_EVENTS table, allowing for exporting to an external system on a schedule to be determined.  Since AnalyticsPortalEvents by default will not be processed, schools that enable AnalyticsPortalEvents will need to create a process to manage the size of the UP_ANALYTICS_EVENTS table.  However, the number of records that are expected to received is relatively small.


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
