### PR TITLE
UPSE-386: Update to optionally include 'favorite' flag in portlet sea…

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -11,6 +11,14 @@
                timeToIdleSeconds="0" timeToLiveSeconds="600" memoryStoreEvictionPolicy="LRU" statistics="true"/>
     ```
 
+- new property, org.apereo.portal.rest.search.PortletsSearchStrategy.displayFavoriteFlag in `portal.properties`
+    ```properties
+    ##
+    ## Flag to enable or disable the display of the favorite flag in the results
+    ##
+    org.apereo.portal.rest.search.PortletsSearchStrategy.displayFavoriteFlag:true
+    ```
+
 ## v5.14.0
 
 - new properties, HTTP Security Headers in `security.properties`

--- a/uPortal-webapp/src/main/resources/properties/portal.properties
+++ b/uPortal-webapp/src/main/resources/properties/portal.properties
@@ -546,6 +546,11 @@ org.apereo.portal.portlet.container.services.PortletCookieServiceImpl.portalCook
 org.apereo.portal.rest.search.PortletsSearchStrategy.displayScore:true
 
 ##
+## Flag to enable or disable the display of the favorite flag in the results
+##
+org.apereo.portal.rest.search.PortletsSearchStrategy.displayFavoriteFlag:true
+
+##
 ## Strings for the search result type for various search services
 ##
 org.apereo.portal.portlets.directory.search.result.type=Directory


### PR DESCRIPTION
…rch results

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included
-   [x] new general keys and comments added to `portal.properties`
-   [x] any changes that impact configuration or the database DDL added to `CHANGES.md`

##### Description of change
<!-- Provide a description of the change below this comment. -->
The portlets search API ( /uPortal/api/v5-0/portal/search?q={search term}*&type=portlets) has been updated to include "favorite" property in the results.

```
{"portlets":[
{"description":"Collection of administrative tools displayed in the ESCO Content Grid","favorite":"false","fname":"admin-dashboard","name":"Admin Dashboard","score":"5.0","title":"Admin Dashboard","url":"/uPortal/f/admin/p/admin-dashboard.u13l1n9/max/render.uP"},{"description":"Administrative functions for tenants in the portal","favorite":"false","fname":"tenant-portal-administration","name":"Tenant Portal Administration","score":"4.0","title":"Tenant Portal Administration","url":"/uPortal/p/tenant-portal-administration.ctf4/max/render.uP"},{"description":"Useful administrative links for managing portal entities and impersonating users","favorite":"false","fname":"portal-administration","name":"Portal Administration","score":"4.0","title":"Portal Administration","url":"/uPortal/p/portal-administration.ctf5/max/render.uP"},
{"description":"Portlet for Portlet Administration","favorite":"true","fname":"portlet-admin","name":"Portlet Administration","score":"4.0","title":"Portlet Administration","url":"/uPortal/f/u15l1s4/p/portlet
```
A new property has been added to enable/disable this:
`org.apereo.portal.rest.search.PortletsSearchStrategy.displayFavoriteFlag`

There was no existing unit test class for PortletsSearchStrategy.  A brief attempt to create one was made, but it was determined that it would take to much time and require some refactoring.
<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
