### PR TITLE
chore: disable javdoc (for now)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,9 +139,9 @@ subprojects {
         required { gradle.taskGraph.hasTask('uploadArchives') }
         sign configurations.archives
     }
-    tasks.withType(Javadoc) {
-        // FIXME: Fix errors rather than supressing them
-        failOnError = false
+    tasks.withType(Javadoc).all {
+        // disable JavaDocs until we start using them again in our website
+        enabled = false
     }
     tasks.withType(Jar) {
         from(project.projectDir) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/uPortal-Project/uPortal/issues

Contributors guide: https://github.com/uPortal-Project/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Disable JavaDoc generation to clean up the console output when building.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#commit
[message properties]: https://github.com/uPortal-Project/uPortal/tree/master/uPortal-webapp/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
