### PR TITLE
Fix flaky tests: JSON comparison

### DIFF
--- a/uPortal-webapp/src/test/java/org/apereo/portal/events/AnalyticsIncorporationComponentEventSerializationTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/events/AnalyticsIncorporationComponentEventSerializationTest.java
@@ -79,7 +79,10 @@ public class AnalyticsIncorporationComponentEventSerializationTest {
                 analyticsIncorporationComponent.serializePortletRenderExecutionEvents(portalEvents);
 
         ObjectMapper objectMapper = new ObjectMapper();
-        assertEquals(objectMapper.readTree("{\"pw1\":{\"fname\":\"fname1\",\"executionTimeNano\":123450000}}"), objectMapper.readTree(result));
+        assertEquals(
+                objectMapper.readTree(
+                        "{\"pw1\":{\"fname\":\"fname1\",\"executionTimeNano\":123450000}}"),
+                objectMapper.readTree(result));
     }
 
     private static class TestableAnalyticsIncorporationComponent
@@ -139,8 +142,9 @@ public class AnalyticsIncorporationComponentEventSerializationTest {
 
         ObjectMapper objectMapper = new ObjectMapper();
         assertEquals(
-            objectMapper.readTree("{\"@c\":\".PortletRenderExecutionEvent\",\"fname\":\"fname1\",\"executionTimeNano\":123450000,\"parameters\":{}}"),
-            objectMapper.readTree(result));
+                objectMapper.readTree(
+                        "{\"@c\":\".PortletRenderExecutionEvent\",\"fname\":\"fname1\",\"executionTimeNano\":123450000,\"parameters\":{}}"),
+                objectMapper.readTree(result));
     }
 
     /**

--- a/uPortal-webapp/src/test/java/org/apereo/portal/events/AnalyticsIncorporationComponentEventSerializationTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/events/AnalyticsIncorporationComponentEventSerializationTest.java
@@ -78,7 +78,8 @@ public class AnalyticsIncorporationComponentEventSerializationTest {
         final String result =
                 analyticsIncorporationComponent.serializePortletRenderExecutionEvents(portalEvents);
 
-        assertEquals("{\"pw1\":{\"fname\":\"fname1\",\"executionTimeNano\":123450000}}", result);
+        ObjectMapper objectMapper = new ObjectMapper();
+        assertEquals(objectMapper.readTree("{\"pw1\":{\"fname\":\"fname1\",\"executionTimeNano\":123450000}}"), objectMapper.readTree(result));
     }
 
     private static class TestableAnalyticsIncorporationComponent
@@ -136,9 +137,10 @@ public class AnalyticsIncorporationComponentEventSerializationTest {
 
         final String result = portletEventWriter.writeValueAsString(createEvent());
 
+        ObjectMapper objectMapper = new ObjectMapper();
         assertEquals(
-                "{\"@c\":\".PortletRenderExecutionEvent\",\"fname\":\"fname1\",\"executionTimeNano\":123450000,\"parameters\":{}}",
-                result);
+            objectMapper.readTree("{\"@c\":\".PortletRenderExecutionEvent\",\"fname\":\"fname1\",\"executionTimeNano\":123450000,\"parameters\":{}}"),
+            objectMapper.readTree(result));
     }
 
     /**

--- a/uPortal-webapp/src/test/java/org/apereo/portal/events/tincan/json/LrsDataModelSerializeTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/events/tincan/json/LrsDataModelSerializeTest.java
@@ -50,8 +50,10 @@ public class LrsDataModelSerializeTest {
         final LrsActor lrsActor = new LrsActor("user@example.com", "John Doe");
 
         final String result = this.objectMapper.writeValueAsString(lrsActor);
-        assertEquals(objectMapper.readTree("{\"mbox\":\"user@example.com\",\"name\":\"John Doe\",\"objectType\":\"Agent\"}"),
-            objectMapper.readTree(result));
+        assertEquals(
+                objectMapper.readTree(
+                        "{\"mbox\":\"user@example.com\",\"name\":\"John Doe\",\"objectType\":\"Agent\"}"),
+                objectMapper.readTree(result));
     }
 
     @Test
@@ -72,8 +74,10 @@ public class LrsDataModelSerializeTest {
 
         final String result = this.objectMapper.writeValueAsString(lrsObject);
 
-        assertEquals(objectMapper.readTree("{\"id\":\"urn:tincan:uportal:activities:portlet:fname\",\"objectType\":\"Activity\",\"definition\":{\"name\":{\"en-US\":\"Portlet Name\"},\"description\":{\"en-US\":\"Portlet Description\"}}}"),
-            objectMapper.readTree(result));
+        assertEquals(
+                objectMapper.readTree(
+                        "{\"id\":\"urn:tincan:uportal:activities:portlet:fname\",\"objectType\":\"Activity\",\"definition\":{\"name\":{\"en-US\":\"Portlet Name\"},\"description\":{\"en-US\":\"Portlet Description\"}}}"),
+                objectMapper.readTree(result));
     }
 
     @Test
@@ -99,7 +103,9 @@ public class LrsDataModelSerializeTest {
 
         final String result = this.objectMapper.writeValueAsString(lrsStatement);
 
-        assertEquals(objectMapper.readTree("{\"actor\":{\"mbox\":\"user@example.com\",\"name\":\"John Doe\",\"objectType\":\"Agent\"},\"verb\":{\"id\":\"http://adlnet.gov/expapi/verbs/initialized\",\"display\":{\"en-us\":\"initialized\"}},\"object\":{\"id\":\"urn:tincan:uportal:activities:portlet:fname\",\"objectType\":\"Activity\",\"definition\":{\"name\":{\"en-US\":\"Portlet Name\"},\"description\":{\"en-US\":\"Portlet Description\"}}}}"),
-            objectMapper.readTree(result));
+        assertEquals(
+                objectMapper.readTree(
+                        "{\"actor\":{\"mbox\":\"user@example.com\",\"name\":\"John Doe\",\"objectType\":\"Agent\"},\"verb\":{\"id\":\"http://adlnet.gov/expapi/verbs/initialized\",\"display\":{\"en-us\":\"initialized\"}},\"object\":{\"id\":\"urn:tincan:uportal:activities:portlet:fname\",\"objectType\":\"Activity\",\"definition\":{\"name\":{\"en-US\":\"Portlet Name\"},\"description\":{\"en-US\":\"Portlet Description\"}}}}"),
+                objectMapper.readTree(result));
     }
 }

--- a/uPortal-webapp/src/test/java/org/apereo/portal/events/tincan/json/LrsDataModelSerializeTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/events/tincan/json/LrsDataModelSerializeTest.java
@@ -50,10 +50,8 @@ public class LrsDataModelSerializeTest {
         final LrsActor lrsActor = new LrsActor("user@example.com", "John Doe");
 
         final String result = this.objectMapper.writeValueAsString(lrsActor);
-
-        assertEquals(
-                "{\"mbox\":\"user@example.com\",\"name\":\"John Doe\",\"objectType\":\"Agent\"}",
-                result);
+        assertEquals(objectMapper.readTree("{\"mbox\":\"user@example.com\",\"name\":\"John Doe\",\"objectType\":\"Agent\"}"),
+            objectMapper.readTree(result));
     }
 
     @Test
@@ -74,9 +72,8 @@ public class LrsDataModelSerializeTest {
 
         final String result = this.objectMapper.writeValueAsString(lrsObject);
 
-        assertEquals(
-                "{\"id\":\"urn:tincan:uportal:activities:portlet:fname\",\"objectType\":\"Activity\",\"definition\":{\"name\":{\"en-US\":\"Portlet Name\"},\"description\":{\"en-US\":\"Portlet Description\"}}}",
-                result);
+        assertEquals(objectMapper.readTree("{\"id\":\"urn:tincan:uportal:activities:portlet:fname\",\"objectType\":\"Activity\",\"definition\":{\"name\":{\"en-US\":\"Portlet Name\"},\"description\":{\"en-US\":\"Portlet Description\"}}}"),
+            objectMapper.readTree(result));
     }
 
     @Test
@@ -102,8 +99,7 @@ public class LrsDataModelSerializeTest {
 
         final String result = this.objectMapper.writeValueAsString(lrsStatement);
 
-        assertEquals(
-                "{\"actor\":{\"mbox\":\"user@example.com\",\"name\":\"John Doe\",\"objectType\":\"Agent\"},\"verb\":{\"id\":\"http://adlnet.gov/expapi/verbs/initialized\",\"display\":{\"en-us\":\"initialized\"}},\"object\":{\"id\":\"urn:tincan:uportal:activities:portlet:fname\",\"objectType\":\"Activity\",\"definition\":{\"name\":{\"en-US\":\"Portlet Name\"},\"description\":{\"en-US\":\"Portlet Description\"}}}}",
-                result);
+        assertEquals(objectMapper.readTree("{\"actor\":{\"mbox\":\"user@example.com\",\"name\":\"John Doe\",\"objectType\":\"Agent\"},\"verb\":{\"id\":\"http://adlnet.gov/expapi/verbs/initialized\",\"display\":{\"en-us\":\"initialized\"}},\"object\":{\"id\":\"urn:tincan:uportal:activities:portlet:fname\",\"objectType\":\"Activity\",\"definition\":{\"name\":{\"en-US\":\"Portlet Name\"},\"description\":{\"en-US\":\"Portlet Description\"}}}}"),
+            objectMapper.readTree(result));
     }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
This PR aims to fix the following 5 flaky test:

1. [org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsActorSerialize](https://github.com/KiruthikaJanakiraman/uPortal/blob/59f8895fe98782e1ff23dd14f9eb2076db09b04e/uPortal-webapp/src/test/java/org/apereo/portal/events/tincan/json/LrsDataModelSerializeTest.java#L49-L57)
2. [org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsObjectSerialize](https://github.com/KiruthikaJanakiraman/uPortal/blob/59f8895fe98782e1ff23dd14f9eb2076db09b04e/uPortal-webapp/src/test/java/org/apereo/portal/events/tincan/json/LrsDataModelSerializeTest.java#L60-L80)
3. [org.apereo.portal.events.AnalyticsIncorporationComponentEventSerializationTest.testMixinNoCopy](https://github.com/KiruthikaJanakiraman/uPortal/blob/59f8895fe98782e1ff23dd14f9eb2076db09b04e/uPortal-webapp/src/test/java/org/apereo/portal/events/AnalyticsIncorporationComponentEventSerializationTest.java#L124-L142)
4. [org.apereo.portal.events.AnalyticsIncorporationComponentEventSerializationTest.testEventFiltering](https://github.com/KiruthikaJanakiraman/uPortal/blob/59f8895fe98782e1ff23dd14f9eb2076db09b04e/uPortal-webapp/src/test/java/org/apereo/portal/events/AnalyticsIncorporationComponentEventSerializationTest.java#L58-L82)
5. [org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsStatementSerialize](https://github.com/KiruthikaJanakiraman/uPortal/blob/59f8895fe98782e1ff23dd14f9eb2076db09b04e/uPortal-webapp/src/test/java/org/apereo/portal/events/tincan/json/LrsDataModelSerializeTest.java#L83-L108)

I found and confirmed the flaky behavior of the tests using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

**Problem**
The test case [org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsActorSerialize](https://github.com/KiruthikaJanakiraman/uPortal/blob/59f8895fe98782e1ff23dd14f9eb2076db09b04e/uPortal-webapp/src/test/java/org/apereo/portal/events/tincan/json/LrsDataModelSerializeTest.java#L49-L57) fails due to the below assertion as the order of the fields within the object `lrsActor` changes  upon nondeterministic shuffling causing the order of JSON string `result` to change.

https://github.com/uPortal-Project/uPortal/blob/59f8895fe98782e1ff23dd14f9eb2076db09b04e/uPortal-webapp/src/test/java/org/apereo/portal/events/tincan/json/LrsDataModelSerializeTest.java#L52-L57

**Solution**
This PR fixes the flakiness by using an [ObjectMapper](https://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.9.8/com/fasterxml/jackson/databind/ObjectMapper.html) class to convert the JSON strings to [JsonNode](https://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.9.8/com/fasterxml/jackson/databind/JsonNode.html) and then comparing the JsonNodes using [JsonNode.equals](https://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/2.9.8/com/fasterxml/jackson/databind/JsonNode.html#equals-java.lang.Object-) method which performs a full(deep) comparison.

The other 4 test are also fixed similarly using this method.

**Steps to reproduce**
The following command can be used to reproduce the assertion errors and verify the fix.

**Integrate NonDex:**

**Add the following snippet to the top of the build.gradle in $PROJ_DIR:**
```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

**Append to build.gradle in $PROJ_DIR:**
```
apply plugin: 'edu.illinois.nondex'
```

**Execute Test with Gradle:**
```
./gradlew --info uPortal-webapp:test --tests org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsActorSerialize
./gradlew --info uPortal-webapp:test --tests org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsObjectSerialize
./gradlew --info uPortal-webapp:test --tests org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsStatementSerialize
./gradlew --info uPortal-webapp:test --tests org.apereo.portal.events.AnalyticsIncorporationComponentEventSerializationTest.testEventFiltering
./gradlew --info uPortal-webapp:test --tests org.apereo.portal.events.AnalyticsIncorporationComponentEventSerializationTest.testMixinNoCopy
```

**Run NonDex:**
```
./gradlew --info uPortal-webapp:nondexTest --tests=org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsActorSerialize --nondexRuns=50 -x autoLintGradle
./gradlew --info uPortal-webapp:nondexTest --tests=org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsObjectSerialize --nondexRuns=50 -x autoLintGradle
./gradlew --info uPortal-webapp:nondexTest --tests=org.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsStatementSerialize --nondexRuns=50 -x autoLintGradle
./gradlew --info uPortal-webapp:nondexTest --tests=org.apereo.portal.events.AnalyticsIncorporationComponentEventSerializationTest.testEventFiltering --nondexRuns=50 -x autoLintGradle
./gradlew --info uPortal-webapp:nondexTest --tests=org.apereo.portal.events.AnalyticsIncorporationComponentEventSerializationTest.testMixinNoCopy --nondexRuns=50 -x autoLintGradle
```

**Test Environment:**
```
Java version "1.8.0_381"
macOS Venture Version 13.4.1 (22F82)
```

Please let me know if you have any concerns or questions.


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
