### PR TITLE
Fix flaky test: testStylesheetDescriptor40ImportExport

### DIFF
--- a/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/IdentityImportExportTestUtilities.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/IdentityImportExportTestUtilities.java
@@ -22,11 +22,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.util.Collections;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.transform.stax.StAXSource;
 import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.IOUtils;
+import org.apereo.portal.io.xml.ssd.ExternalStylesheetDescriptor;
 import org.custommonkey.xmlunit.Diff;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.springframework.core.io.Resource;
@@ -81,6 +83,10 @@ public final class IdentityImportExportTestUtilities {
 
         // Make sure the data was exported
         assertNotNull("Exported data was null", dataExport);
+        if(resource.getFilename().equals("test_4-0.stylesheet-descriptor.xml"))
+        {
+            Collections.sort(((ExternalStylesheetDescriptor) dataExport).getLayoutAttributes().get(0).getTargetElements());
+        }
 
         // Marshall to XML
         final Marshaller marshaller = dataExporter.getMarshaller();

--- a/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/IdentityImportExportTestUtilities.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/IdentityImportExportTestUtilities.java
@@ -83,9 +83,12 @@ public final class IdentityImportExportTestUtilities {
 
         // Make sure the data was exported
         assertNotNull("Exported data was null", dataExport);
-        if(resource.getFilename().equals("test_4-0.stylesheet-descriptor.xml"))
-        {
-            Collections.sort(((ExternalStylesheetDescriptor) dataExport).getLayoutAttributes().get(0).getTargetElements());
+        if (resource.getFilename().equals("test_4-0.stylesheet-descriptor.xml")) {
+            Collections.sort(
+                    ((ExternalStylesheetDescriptor) dataExport)
+                            .getLayoutAttributes()
+                            .get(0)
+                            .getTargetElements());
         }
 
         // Marshall to XML


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
This PR aims to fix the flaky test: [org.apereo.portal.io.xml.IdentityImportExportTest.testStylesheetDescriptor40ImportExport](https://github.com/uPortal-Project/uPortal/blob/1ff2f1991f4fcae7d629c4faa4efb9315aa19297/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/IdentityImportExportTest.java#L190) similar to previously raised PRs: https://github.com/uPortal-Project/uPortal/pull/2718 and https://github.com/uPortal-Project/uPortal/pull/2719

I found and confirmed the flaky behaviour of the tests using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

**Problem**
The test case [org.apereo.portal.io.xml.IdentityImportExportTest.testStylesheetDescriptor40ImportExport](https://github.com/uPortal-Project/uPortal/blob/1ff2f1991f4fcae7d629c4faa4efb9315aa19297/uPortal-webapp/src/test/java/org/apereo/portal/io/xml/IdentityImportExportTest.java#L190) fails because the order of `targetElements`: `channel` and `portlet` in the exported xml varies upon nondeterministic shuffling.

https://github.com/uPortal-Project/uPortal/blob/7fe3d5d9078bd0be9b0442be37067bb399eab7fd/uPortal-webapp/src/test/resources/org/apereo/portal/io/xml/ssd/test_4-0.stylesheet-descriptor.xml#L49-L50

**Solution**
This PR fixes the flakiness by sorting the `targetElements` in exportData before comparing importData and exportData XMLs.

**Steps to reproduce**
The following command can be used to reproduce the assertion errors and verify the fix.

**Integrate NonDex:**

**Add the following snippet to the top of the build.gradle in $PROJ_DIR:**
```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

**Append to build.gradle in $PROJ_DIR:**
```
apply plugin: 'edu.illinois.nondex'
```

**Execute Test with Gradle:**
```
./gradlew --info uPortal-webapp:test --tests org.apereo.portal.io.xml.IdentityImportExportTest.testStylesheetDescriptor40ImportExport
```

**Run NonDex:**
```
./gradlew --info uPortal-webapp:nondexTest --tests=org.apereo.portal.io.xml.IdentityImportExportTest.testStylesheetDescriptor40ImportExport --nondexRuns=50 -x autoLintGradle
```

**Test Environment:**
```
Java version "1.8.0_381"
macOS Venture Version 13.4.1 (22F82)
```

Please let me know if you have any concerns or questions.


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl