### PR TITLE
fix: move .active CSS back in correct order

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/navigation.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/less/navigation.less
@@ -418,22 +418,6 @@
           margin-left: 64px;
           width: initial;
 
-          .active {
-            background-color: @navbar-item-active-background-color;
-            color: @navbar-item-active-text-color;
-
-            &:hover,
-            &:focus {
-              .portal-navigation-gripper {
-                background-color: transparent;
-              }
-            }
-
-            .portal-navigation-link {
-              float: left;
-            }
-          }
-
           :not(.active).list-group-item {
             &:hover,
             &:focus {
@@ -620,6 +604,22 @@
                   }
                 }
               }
+            }
+          }
+
+          .active {
+            background-color: @navbar-item-active-background-color;
+            color: @navbar-item-active-text-color;
+
+            &:hover,
+            &:focus {
+              .portal-navigation-gripper {
+                background-color: transparent;
+              }
+            }
+
+            .portal-navigation-link {
+              float: left;
             }
           }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/uPortal-Project/uPortal/issues

Contributors guide: https://github.com/uPortal-Project/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Prashanti from Texas A&M reported that re-ordering in nav LESS file broken a visual. This PR moves the .active entry lower to address the issue.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#commit
[message properties]: https://github.com/uPortal-Project/uPortal/tree/master/uPortal-webapp/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
