### PR TITLE
fix: throw error on bad pCt parameter (security issue)

### DIFF
--- a/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/TransientUserLayoutManagerWrapper.java
+++ b/uPortal-layout/uPortal-layout-impl/src/main/java/org/apereo/portal/layout/TransientUserLayoutManagerWrapper.java
@@ -390,7 +390,7 @@ public class TransientUserLayoutManagerWrapper implements IUserLayoutManager {
                                 + fname
                                 + "\" : "
                                 + e);
-                subId = null;
+                throw e;
             }
         }
         return subId;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/uPortal-Project/uPortal/issues

Contributors guide: https://github.com/uPortal-Project/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [ ] tests are included

##### Description of change
<!-- Provide a description of the change below this comment. -->
Client reported that security scans have reported that the `pCt` parameter that usually takes the fname of a portlet returns a 200 code if that is set to a file path. While it does not deliver files, the 200 code is an issue. Failure to find an fname is either an consistency issue or someone hacking.

Fix is to throw the exception (rather than swallow it) when the pCt specified portlet is not found.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#commit
[message properties]: https://github.com/uPortal-Project/uPortal/tree/master/uPortal-webapp/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
