### PR TITLE
Fix for PortletEventCoordinationHelper instantiation

### DIFF
--- a/uPortal-web/src/main/java/org/apereo/portal/portlet/rendering/PortletEventCoordinatationService.java
+++ b/uPortal-web/src/main/java/org/apereo/portal/portlet/rendering/PortletEventCoordinatationService.java
@@ -115,13 +115,13 @@ public class PortletEventCoordinatationService implements IPortletEventCoordinat
         this.portletEntityRegistry = portletEntityRegistry;
     }
 
-    protected final PortletEventCoordinationHelper portletEventCoordinationHelper =
-            new PortletEventCoordinationHelper(
-                    this.xmlUtilities,
-                    this.portletContextService,
-                    this.portletWindowRegistry,
-                    this.supportedEventCache,
-                    this.portletDefinitionRegistry);
+    protected PortletEventCoordinationHelper portletEventCoordinationHelper;
+
+    @Autowired
+    public void setPortletEventCoordinationHelper(
+            PortletEventCoordinationHelper portletEventCoordinationHelper) {
+        this.portletEventCoordinationHelper = portletEventCoordinationHelper;
+    }
 
     /**
      * Returns a request scoped PortletEventQueue used to track events to process and events to

--- a/uPortal-web/src/main/java/org/apereo/portal/portlet/rendering/PortletEventCoordinationHelper.java
+++ b/uPortal-web/src/main/java/org/apereo/portal/portlet/rendering/PortletEventCoordinationHelper.java
@@ -28,6 +28,8 @@ import org.apereo.portal.portlet.registry.IPortletDefinitionRegistry;
 import org.apereo.portal.portlet.registry.IPortletWindowRegistry;
 import org.apereo.portal.utils.Tuple;
 import org.apereo.portal.xml.XmlUtilities;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -37,21 +39,34 @@ public class PortletEventCoordinationHelper {
     private PortletContextService portletContextService;
     private IPortletWindowRegistry portletWindowRegistry;
     private Ehcache supportedEventCache;
+    private IPortletDefinitionRegistry portletDefinitionRegistry;
 
-    public PortletEventCoordinationHelper(
-            XmlUtilities xmlUtilities,
-            PortletContextService portletContextService,
-            IPortletWindowRegistry portletWindowRegistry,
-            Ehcache supportedEventCache,
-            IPortletDefinitionRegistry portletDefinitionRegistry) {
-        this.xmlUtilities = xmlUtilities;
-        this.portletContextService = portletContextService;
-        this.portletWindowRegistry = portletWindowRegistry;
+    @Autowired
+    public void setSupportedEventCache(
+            @Qualifier("org.apereo.portal.portlet.rendering.SupportedEventCache")
+                    Ehcache supportedEventCache) {
         this.supportedEventCache = supportedEventCache;
-        this.portletDefinitionRegistry = portletDefinitionRegistry;
     }
 
-    private IPortletDefinitionRegistry portletDefinitionRegistry;
+    @Autowired
+    public void setXmlUtilities(XmlUtilities xmlUtilities) {
+        this.xmlUtilities = xmlUtilities;
+    }
+
+    @Autowired
+    public void setPortletContextService(PortletContextService portletContextService) {
+        this.portletContextService = portletContextService;
+    }
+
+    @Autowired
+    public void setPortletWindowRegistry(IPortletWindowRegistry portletWindowRegistry) {
+        this.portletWindowRegistry = portletWindowRegistry;
+    }
+
+    @Autowired
+    public void setPortletDefinitionRegistry(IPortletDefinitionRegistry portletDefinitionRegistry) {
+        this.portletDefinitionRegistry = portletDefinitionRegistry;
+    }
 
     protected Event unmarshall(IPortletWindow portletWindow, Event event) {
         // TODO make two types of Event impls, one for marshalled data and one for unmarshalled data

--- a/uPortal-web/src/main/java/org/apereo/portal/portlet/rendering/PortletEventCoordinationHelper.java
+++ b/uPortal-web/src/main/java/org/apereo/portal/portlet/rendering/PortletEventCoordinationHelper.java
@@ -35,38 +35,15 @@ import org.springframework.stereotype.Component;
 @Component
 public class PortletEventCoordinationHelper {
     public static final String GLOBAL_EVENT__CONTAINER_OPTION = "org.apereo.portal.globalEvent";
-    private XmlUtilities xmlUtilities;
-    private PortletContextService portletContextService;
-    private IPortletWindowRegistry portletWindowRegistry;
+    @Autowired private XmlUtilities xmlUtilities;
+    @Autowired private PortletContextService portletContextService;
+    @Autowired private IPortletWindowRegistry portletWindowRegistry;
+
+    @Autowired
+    @Qualifier("org.apereo.portal.portlet.rendering.SupportedEventCache")
     private Ehcache supportedEventCache;
-    private IPortletDefinitionRegistry portletDefinitionRegistry;
 
-    @Autowired
-    public void setSupportedEventCache(
-            @Qualifier("org.apereo.portal.portlet.rendering.SupportedEventCache")
-                    Ehcache supportedEventCache) {
-        this.supportedEventCache = supportedEventCache;
-    }
-
-    @Autowired
-    public void setXmlUtilities(XmlUtilities xmlUtilities) {
-        this.xmlUtilities = xmlUtilities;
-    }
-
-    @Autowired
-    public void setPortletContextService(PortletContextService portletContextService) {
-        this.portletContextService = portletContextService;
-    }
-
-    @Autowired
-    public void setPortletWindowRegistry(IPortletWindowRegistry portletWindowRegistry) {
-        this.portletWindowRegistry = portletWindowRegistry;
-    }
-
-    @Autowired
-    public void setPortletDefinitionRegistry(IPortletDefinitionRegistry portletDefinitionRegistry) {
-        this.portletDefinitionRegistry = portletDefinitionRegistry;
-    }
+    @Autowired private IPortletDefinitionRegistry portletDefinitionRegistry;
 
     protected Event unmarshall(IPortletWindow portletWindow, Event event) {
         // TODO make two types of Event impls, one for marshalled data and one for unmarshalled data


### PR DESCRIPTION
Autowired all fields. Added a qualifier for Ehcache. Removed constructor and reference.

##### Checklist

-   [X] commit message follows [commit guidelines][]

##### Description of change
A recent refactor broke proper startup of uP. This PR fixes things by adding more Spring `@Autowired` and `@Qualifier` bean management.