### PR TITLE
fix: added fn configureDefaults() to up-ga.js

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/up-ga.js
+++ b/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/up-ga.js
@@ -48,14 +48,16 @@ var uportal = uportal || {};
     /**
      * Set the defaultConfig.config array as global settings
      */
-    var configureDefaults = function(propertyConfig) {
+    var configureDefaults = function (propertyConfig) {
         const defaults = propertyConfig.config;
-        defaults.forEach(function(setting) {
-            Object.entries(setting).forEach(function([key, value]) {
-                gtag('set', key, value);
-            })
-        });
-    }
+        for (const setting of defaults) {
+        /*
+            for (const [key, value] of Object.entries(setting)) {
+                up.gtag('set', key, value);
+            }
+        */
+        }
+    };
 
     /**
      * Set the dimensions that apply to the current user

--- a/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/up-ga.js
+++ b/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/up-ga.js
@@ -46,6 +46,18 @@ var uportal = uportal || {};
     };
 
     /**
+     * Set the defaultConfig.config array as global settings
+     */
+    var configureDefaults = function(propertyConfig) {
+        const defaults = propertyConfig.config;
+        defaults.forEach(function(setting) {
+            Object.entries(setting).forEach(function([key, value]) {
+                gtag('set', key, value);
+            })
+        });
+    }
+
+    /**
      * Set the dimensions that apply to the current user
      */
     var getDimensions = function (propertyConfig) {
@@ -370,6 +382,9 @@ var uportal = uportal || {};
         if (propertyConfig == null) {
             return;
         }
+
+        // Set default config
+        configureDefaults(propertyConfig);
 
         // Create the tracker
         createTracker(propertyConfig);

--- a/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/up-ga.js
+++ b/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/up-ga.js
@@ -51,10 +51,10 @@ var uportal = uportal || {};
     var configureDefaults = function (propertyConfig) {
         //console.log(propertyConfig);
         var defaults = propertyConfig.config || [];
-        _.each(defaults, function(setting) {
+        _.each(defaults, function (setting) {
             // each setting is an object that might have more than 1 key-value pair
             //console.log(setting);
-            _.each(Object.keys(setting), function(key) {
+            _.each(Object.keys(setting), function (key) {
                 up.gtag('set', key, setting[key]);
             });
         });

--- a/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/up-ga.js
+++ b/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/up-ga.js
@@ -49,14 +49,15 @@ var uportal = uportal || {};
      * Set the defaultConfig.config array as global settings
      */
     var configureDefaults = function (propertyConfig) {
-        const defaults = propertyConfig.config;
-        for (const setting of defaults) {
-        /*
-            for (const [key, value] of Object.entries(setting)) {
-                up.gtag('set', key, value);
-            }
-        */
-        }
+        //console.log(propertyConfig);
+        var defaults = propertyConfig.config || [];
+        _.each(defaults, function(setting) {
+            // each setting is an object that might have more than 1 key-value pair
+            //console.log(setting);
+            _.each(Object.keys(setting), function(key) {
+                up.gtag('set', key, setting[key]);
+            });
+        });
     };
 
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/uPortal-Project/uPortal/issues

Contributors guide: https://github.com/uPortal-Project/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Default GA configuration is not being set. This change adds setting the defaults as global values.

Use of archaic JS compressor prevents use of modern ES6. Will be addressed in uPortal v6, but for now the code was rewritten in an older style that matches the rest of the file.

<!-- Reference Links -->
https://developers.google.com/analytics/devguides/collection/ga4/reference/config#:~:text=Set%20to%20'auto'%20(the,example.com%20for%20the%20domain.

[individual contributor license agreement]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#commit
[message properties]: https://github.com/uPortal-Project/uPortal/tree/master/uPortal-webapp/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
