### PR TITLE
Added filter to getPeopleWithMultivaluedAttributes caching

### DIFF
--- a/uPortal-events/src/main/java/org/apereo/portal/utils/cache/PersonDirectoryCacheKeyGenerator.java
+++ b/uPortal-events/src/main/java/org/apereo/portal/utils/cache/PersonDirectoryCacheKeyGenerator.java
@@ -78,6 +78,7 @@ public class PersonDirectoryCacheKeyGenerator implements CacheKeyGenerator {
                 // Both methods that take a Map argument can just have the first argument returned
             case PEOPLE_MAP:
             case PEOPLE_MULTIVALUED_MAP:
+            case PEOPLE_MULTIVALUED_MAP_FILTER:
             case MULTIVALUED_USER_ATTRIBUTES__MAP:
             case USER_ATTRIBUTES__MAP:
                 {
@@ -250,6 +251,10 @@ public class PersonDirectoryCacheKeyGenerator implements CacheKeyGenerator {
         PERSON_STR("getPerson", String.class),
         PEOPLE_MAP("getPeople", Map.class),
         PEOPLE_MULTIVALUED_MAP("getPeopleWithMultivaluedAttributes", Map.class),
+        PEOPLE_MULTIVALUED_MAP_FILTER(
+                "getPeopleWithMultivaluedAttributes",
+                Map.class,
+                org.apereo.services.persondir.IPersonAttributeDaoFilter.class),
         POSSIBLE_USER_ATTRIBUTE_NAMES("getPossibleUserAttributeNames"),
         AVAILABLE_QUERY_ATTRIBUTES("getAvailableQueryAttributes");
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/uPortal-Project/uPortal/issues

Contributors guide: https://github.com/uPortal-Project/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [X] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
PR 2280 introduced a bug related to attempted caching of the IPersonAttributeDao.getPeopleWithMultivaluedAttributes method. This PR fixes that bug by adding the newly introduced filter to PersonDirectoryCacheKeyGenerator.CachableMethod enum and reference.

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/uPortal-Project/uPortal/blob/master/docs/CONTRIBUTING.md#commit
[message properties]: https://github.com/uPortal-Project/uPortal/tree/master/uPortal-webapp/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
