### PR TITLE
fix: exclude Spring from resource-server-utils transitive deps

### DIFF
--- a/uPortal-utils/uPortal-utils-core/build.gradle
+++ b/uPortal-utils/uPortal-utils-core/build.gradle
@@ -17,8 +17,14 @@ dependencies {
     api "org.apache.commons:commons-lang3:${commonsLang3Version}"
     api "org.aspectj:aspectjrt:${aspectjVersion}"
     api "com.fasterxml.woodstox:woodstox-core:${woodstoxVersion}"
-    api "org.jasig.resourceserver:resource-server-api:${resourceServerVersion}"
-    api "org.jasig.resourceserver:resource-server-utils:${resourceServerVersion}"
+    api("org.jasig.resourceserver:resource-server-api:${resourceServerVersion}") {
+        exclude group: 'org.springframework', module: 'spring-jcl'
+        exclude group: 'org.slf4j'
+    }
+    api("org.jasig.resourceserver:resource-server-utils:${resourceServerVersion}") {
+        exclude group: 'org.springframework'
+        exclude group: 'org.slf4j'
+    }
     api("org.apereo.service.persondir:person-directory-impl:${personDirectoryVersion}") {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'org.springframework', module: 'spring-beans'


### PR DESCRIPTION
## Summary

uPortal explicitly pins `springVersion=4.3.30.RELEASE`, but `resource-server 1.5.x` transitively depends on Spring 5.x. Without an exclusion, a build bumping `resource-server` to 1.5.x ends up with both Spring versions on the classpath; javac resolves `org.springframework.web.util.UriUtils` against the Spring 5 API where `encodePathSegment(String, String)` no longer declares `throws UnsupportedEncodingException`, and the catch clause in `Util.encodePathSegment()` becomes unreachable:

```
uPortal-utils-core/src/main/java/org/apereo/portal/utils/jsp/Util.java:143:
  error: exception UnsupportedEncodingException is never thrown in body
  of corresponding try statement
```

This is the CI failure blocking #2537 (Renovate's `resource-server 1.3.1 → 1.5.2` bump).

## The fix

Two `<dependency>.exclude` blocks on the `resource-server-api` and `resource-server-utils` declarations in `uPortal-utils/uPortal-utils-core/build.gradle`, cherry-picked verbatim from the equivalent hunk in @Naenyn's #2915 (where the same exclusion is part of a larger 193-file Bootstrap/jQuery PR):

```gradle
api("org.jasig.resourceserver:resource-server-api:${resourceServerVersion}") {
    exclude group: 'org.springframework', module: 'spring-jcl'
    exclude group: 'org.slf4j'
}
api("org.jasig.resourceserver:resource-server-utils:${resourceServerVersion}") {
    exclude group: 'org.springframework'
    exclude group: 'org.slf4j'
}
```

- Narrower exclusion on `resource-server-api` (only `spring-jcl` module + all `slf4j`) — `resource-server-api` is a smaller artifact.
- Broader exclusion on `resource-server-utils` (all `org.springframework` + all `slf4j`) — this is the one that drags in the full Spring 5 web stack.

Landing it independently on master unblocks #2537 without coupling to the Bootstrap/jQuery work in #2915.

## Test plan

Validated locally:

- **master + this change @ `resourceServerVersion=1.3.1`** → `:uPortal-utils:uPortal-utils-core:compileJava BUILD SUCCESSFUL` (exclusion is benign on current master)
- **master + this change @ `resourceServerVersion=1.5.2`** (simulated by editing gradle.properties locally) → `:uPortal-utils:uPortal-utils-core:compileJava BUILD SUCCESSFUL` (Util.java compile error goes away)

## Related PRs — merge order to fully unblock resource-server 1.5.2

1. **This PR** → fixes `Util.java` compile error surfaced by Spring version clash.
2. **#2943** → fixes ErrorProne `CheckReturnValue` on `LimitingTeeWriter` / `LimitingTeeOutputStream` that surfaces when newer Guava comes along via resource-server 1.5.x.
3. **#2537** (Renovate) → the actual `1.3.1 → 1.5.2` bump; CI goes green once both fixes above have landed.
4. **#2915** (Bill's Bootstrap/jQuery PR) → rebases master and gets clean CI, leaving only content review.