### PR TITLE
refactor: convert LimitingTee callbacks Function<T,?> → Consumer<T>

### DIFF
--- a/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/cache/CachingPortletOutputHandler.java
+++ b/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/cache/CachingPortletOutputHandler.java
@@ -14,7 +14,6 @@
  */
 package org.apereo.portal.portlet.container.cache;
 
-import com.google.common.base.Function;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -102,14 +101,7 @@ public class CachingPortletOutputHandler implements PortletOutputHandler {
                             this.maximumSize,
                             delegateWriter,
                             this.cachingWriter,
-                            new Function<LimitingTeeWriter, Object>() {
-                                @Override
-                                public Object apply(LimitingTeeWriter input) {
-                                    // Limit hit, clear the cache
-                                    clearCachedWriter();
-                                    return null;
-                                }
-                            });
+                            input -> clearCachedWriter());
 
             // Wrap the limiting tee writer in a PrintWriter to return to the caller
             this.printWriter = new PrintWriter(this.teeWriter);
@@ -135,14 +127,7 @@ public class CachingPortletOutputHandler implements PortletOutputHandler {
                             this.maximumSize,
                             delegateOutputStream,
                             this.cachingOutputStream,
-                            new Function<LimitingTeeOutputStream, Object>() {
-                                @Override
-                                public Object apply(LimitingTeeOutputStream input) {
-                                    // Limit hit, clear the cache
-                                    clearCachedStream();
-                                    return null;
-                                }
-                            });
+                            input -> clearCachedStream());
         }
 
         return teeStream;

--- a/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/cache/LimitingTeeOutputStream.java
+++ b/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/cache/LimitingTeeOutputStream.java
@@ -14,9 +14,9 @@
  */
 package org.apereo.portal.portlet.container.cache;
 
-import com.google.common.base.Function;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.function.Consumer;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apereo.portal.utils.TeeOutputStream;
 
@@ -24,12 +24,12 @@ import org.apereo.portal.utils.TeeOutputStream;
  * Subclass of {@link TeeOutputStream} that stops writing to the branch once the limit is hit by
  * calling {@link #setBranch(OutputStream)} with {@link NullOutputStream}.
  *
- * <p>A callback {@link Function} to be executed when the limit is hit can be provided as well.
+ * <p>A callback {@link Consumer} to be executed when the limit is hit can be provided as well.
  */
 public class LimitingTeeOutputStream extends TeeOutputStream {
     private final long maximumBytes;
     private final OutputStream branch;
-    private final Function<LimitingTeeOutputStream, ?> limitReachedCallback;
+    private final Consumer<LimitingTeeOutputStream> limitReachedCallback;
     private long byteCount = 0;
     private boolean limitReached = false;
 
@@ -41,7 +41,7 @@ public class LimitingTeeOutputStream extends TeeOutputStream {
             long maximumBytes,
             OutputStream out,
             OutputStream branch,
-            Function<LimitingTeeOutputStream, ?> limitReachedCallback) {
+            Consumer<LimitingTeeOutputStream> limitReachedCallback) {
         super(out, branch);
         this.maximumBytes = maximumBytes;
         this.branch = branch;
@@ -81,10 +81,7 @@ public class LimitingTeeOutputStream extends TeeOutputStream {
             this.setBranch(NullOutputStream.NULL_OUTPUT_STREAM);
 
             if (this.limitReachedCallback != null) {
-                // Named 'unused' to satisfy ErrorProne's CheckReturnValue; the callback's
-                // signature is Function<T,?> but its return value is intentionally discarded.
-                @SuppressWarnings("unused")
-                Object unused = this.limitReachedCallback.apply(this);
+                this.limitReachedCallback.accept(this);
             }
         }
     }

--- a/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/cache/LimitingTeeWriter.java
+++ b/uPortal-rendering/src/main/java/org/apereo/portal/portlet/container/cache/LimitingTeeWriter.java
@@ -14,9 +14,9 @@
  */
 package org.apereo.portal.portlet.container.cache;
 
-import com.google.common.base.Function;
 import java.io.IOException;
 import java.io.Writer;
+import java.util.function.Consumer;
 import org.apache.commons.io.output.NullWriter;
 import org.apereo.portal.utils.TeeWriter;
 
@@ -24,12 +24,12 @@ import org.apereo.portal.utils.TeeWriter;
  * Subclass of {@link TeeWriter} that stops writing to the branch once the limit is hit by calling
  * {@link #setBranch(Writer)} with {@link NullWriter}.
  *
- * <p>A callback {@link Function} to be executed when the limit is hit can be provided as well.
+ * <p>A callback {@link Consumer} to be executed when the limit is hit can be provided as well.
  */
 public class LimitingTeeWriter extends TeeWriter {
     private final long maximumCharacters;
     private final Writer branch;
-    private final Function<LimitingTeeWriter, ?> limitReachedCallback;
+    private final Consumer<LimitingTeeWriter> limitReachedCallback;
     private long characterCount = 0;
     private boolean limitReached = false;
 
@@ -41,7 +41,7 @@ public class LimitingTeeWriter extends TeeWriter {
             long maximumCharacters,
             Writer out,
             Writer branch,
-            Function<LimitingTeeWriter, ?> limitReachedCallback) {
+            Consumer<LimitingTeeWriter> limitReachedCallback) {
         super(out, branch);
         this.maximumCharacters = maximumCharacters;
         this.branch = branch;
@@ -83,10 +83,7 @@ public class LimitingTeeWriter extends TeeWriter {
             this.setBranch(NullWriter.NULL_WRITER);
 
             if (this.limitReachedCallback != null) {
-                // Named 'unused' to satisfy ErrorProne's CheckReturnValue; the callback's
-                // signature is Function<T,?> but its return value is intentionally discarded.
-                @SuppressWarnings("unused")
-                Object unused = this.limitReachedCallback.apply(this);
+                this.limitReachedCallback.accept(this);
             }
         }
     }

--- a/uPortal-webapp/src/test/java/org/apereo/portal/events/aggr/PortalRawEventsAggregatorImplTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/events/aggr/PortalRawEventsAggregatorImplTest.java
@@ -175,13 +175,15 @@ public class PortalRawEventsAggregatorImplTest {
                         new Answer<Boolean>() {
                             @Override
                             public Boolean answer(InvocationOnMock invocation) throws Throwable {
-                                ((Function<PortalEvent, Boolean>) invocation.getArguments()[3])
-                                        .apply(
-                                                new MockPortalEvent(
-                                                        this,
-                                                        "serverName",
-                                                        "eventSessionId",
-                                                        person));
+                                Boolean ignored =
+                                        ((Function<PortalEvent, Boolean>)
+                                                        invocation.getArguments()[3])
+                                                .apply(
+                                                        new MockPortalEvent(
+                                                                this,
+                                                                "serverName",
+                                                                "eventSessionId",
+                                                                person));
 
                                 return false;
                             }

--- a/uPortal-webapp/src/test/java/org/apereo/portal/portlet/container/cache/LimitingTeeOutputStreamTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/portlet/container/cache/LimitingTeeOutputStreamTest.java
@@ -18,7 +18,6 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
 
-import com.google.common.base.Function;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -66,13 +65,7 @@ public class LimitingTeeOutputStreamTest {
                         content.length - 1,
                         NullOutputStream.NULL_OUTPUT_STREAM,
                         byteStream,
-                        new Function<LimitingTeeOutputStream, Object>() {
-                            @Override
-                            public Object apply(LimitingTeeOutputStream input) {
-                                byteStream.reset();
-                                return null;
-                            }
-                        });
+                        input -> byteStream.reset());
         // write the first few chars
         stream.write(content, 0, 5);
         // verify content successfully buffered

--- a/uPortal-webapp/src/test/java/org/apereo/portal/portlet/container/cache/LimitingTeeWriterTest.java
+++ b/uPortal-webapp/src/test/java/org/apereo/portal/portlet/container/cache/LimitingTeeWriterTest.java
@@ -14,7 +14,6 @@
  */
 package org.apereo.portal.portlet.container.cache;
 
-import com.google.common.base.Function;
 import java.io.IOException;
 import org.apache.commons.io.output.NullWriter;
 import org.apache.commons.io.output.StringBuilderWriter;
@@ -60,13 +59,9 @@ public class LimitingTeeWriterTest {
                         content.length() - 1,
                         NullWriter.NULL_WRITER,
                         stringWriter,
-                        new Function<LimitingTeeWriter, Object>() {
-                            @Override
-                            public Object apply(LimitingTeeWriter input) {
-                                final StringBuilder builder = stringWriter.getBuilder();
-                                builder.delete(0, builder.length());
-                                return null;
-                            }
+                        input -> {
+                            final StringBuilder builder = stringWriter.getBuilder();
+                            builder.delete(0, builder.length());
                         });
         // write the first few chars
         writer.write(content.substring(0, 5));


### PR DESCRIPTION
## Summary

Follow-up to #2943, adopting the cleaner design @Naenyn proposed. Replaces the `@SuppressWarnings`/`unused` workaround that just landed with the correct type for a fire-and-forget callback: `java.util.function.Consumer<T>`. With Consumer, `.accept()` returns void and the ErrorProne `CheckReturnValue` check doesn't apply at all — no suppression needed.

## Context — why this is a follow-up rather than an update to #2943

@Naenyn had pushed his Consumer-based version (`Naenyn/uPortal@f2e3a459`) to his `remove_fluid` branch and asked me to adopt it. I force-pushed the cherry-pick onto #2943's branch, but the merge of #2943 had already resolved against the original `@SuppressWarnings` version — the better approach didn't make it in.

This PR lands the same set of changes as a clean follow-up, with @Naenyn credited as co-author. When his #2915 rebases master, these hunks will be no-ops (already on master) and his PR shrinks correspondingly.

## Scope (6 files, +25/−56)

**Source (`uPortal-rendering`)**:

- `LimitingTeeWriter.java` — `Function<LimitingTeeWriter, ?>` → `Consumer<LimitingTeeWriter>`, `.apply(this)` → `.accept(this)`, swap import, update Javadoc reference.
- `LimitingTeeOutputStream.java` — same pattern.
- `CachingPortletOutputHandler.java` (sole caller) — anonymous `Function<>` classes → concise lambdas:
  ```java
  input -> clearCachedWriter()
  input -> clearCachedStream()
  ```
  Drop the now-unused `com.google.common.base.Function` import.

**Tests (`uPortal-webapp`)**:

- `LimitingTeeWriterTest.java`, `LimitingTeeOutputStreamTest.java` — matching Function-to-lambda updates; drop unused Function imports.
- `PortalRawEventsAggregatorImplTest.java` — **different pattern** here: the `Function` comes from the code-under-test's own API, not our types, so it can't be changed to Consumer. Use `Boolean ignored = …` to capture the return (same shape @Naenyn used; aligns with the ErrorProne convention for the cases where the type genuinely can't be changed).

## Validation

- `./gradlew :uPortal-rendering:compileJava` → BUILD SUCCESSFUL
- `./gradlew :uPortal-webapp:compileTestJava` → BUILD SUCCESSFUL
- @Naenyn's `remove_fluid` branch (which has `resourceServerVersion=1.5.2` and therefore triggers the underlying Guava `@CheckReturnValue` check) already builds clean with these exact changes — so the fix addresses the real failure mode.

## Net effect

After this lands, master will carry @Naenyn's original Consumer design rather than the `@SuppressWarnings` workaround. Cleaner code, no behavior change.

cc @Naenyn