### PR TITLE
chore: pin Spring/Hibernate majors in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,31 @@
   "forkProcessing": "enabled",
   "packageRules": [
     {
+      "matchPackageNames": [
+        "/^org.springframework:/",
+        "/^org.springframework.data:/",
+        "/^org.springframework.webflow:/"
+      ],
+      "allowedVersions": "< 5.0",
+      "description": "Pinned to Spring Framework 4.3.x. Spring 5+ is a coordinated migration (API changes); Spring 6+ additionally needs Jakarta EE + Java 17."
+    },
+    {
+      "matchPackageNames": [
+        "/^org.springframework.security:/",
+        "/^org.springframework.security.oauth:/"
+      ],
+      "allowedVersions": "< 5.0",
+      "description": "Pinned to Spring Security 4.2.x. Bound to the Spring Framework 4.3.x line; bumps in lockstep with a Spring core migration."
+    },
+    {
+      "matchPackageNames": [
+        "/^org.hibernate:/",
+        "/^org.hibernate.orm:/"
+      ],
+      "allowedVersions": "< 5.0",
+      "description": "Pinned to Hibernate 4.2.x. Hibernate 5+ requires a coordinated migration (API + EntityManager changes); Hibernate 6+ (groupId rename to org.hibernate.orm) needs Jakarta EE and Java 17+."
+    },
+    {
       "groupName": "uPortal",
       "matchPackageNames": ["/^org.jasig.portal:/"]
     },


### PR DESCRIPTION
## Summary

- Add three `allowedVersions` constraints to `renovate.json` matching how the rest of the fleet is pinned, so Renovate stops opening major-bump PRs for Spring 5/6, Spring Security 5+, and Hibernate 5+.
- This is config-only — no dependency versions change.

## Why

uPortal is on Spring Framework 4.3.30, Spring Security 4.2.20, and Hibernate 4.2.21. Each of those majors requires a coordinated migration we have not scheduled. Renovate keeps surfacing these as `[security]` PRs, which we close every cycle by hand:

- #2942 — `springversion (major)` 
- #2941 — `springsecurityversion to v5 (major)`
- #2940 — `hibernate-core to v5`
- #2937 — `hibernate-core to v5` (duplicate of #2940)

This PR encodes the constraint so they stop coming through.

## Pins added

| GroupIds | Cap | Reason |
|---|---|---|
| `org.springframework:*` / `.data:*` / `.webflow:*` | `< 5.0` | Spring 5+ is an API migration; Spring 6+ also requires Jakarta EE + Java 17 |
| `org.springframework.security:*` / `.oauth:*` | `< 5.0` | Bound to the Spring Framework 4.3.x line; moves in lockstep with a Spring core migration |
| `org.hibernate:*` / `org.hibernate.orm:*` | `< 5.0` | Hibernate 5+ has API + EntityManager changes; 6+ renames the groupId and needs Jakarta EE + Java 17 |

## Not pinned (allowed to proceed normally)

- **Spring LDAP** — #2938 proposes 2.4.4, a minor bump within the 2.x line we're already on
- **Springfox** — #2935 proposes 2.10.0, also a minor within the current 2.x line
- **Guava** — #2939 proposes v32, plausible: resource-server is already on guava 32

## Pattern consistency

Same shape as the renovate.json files added across the portlet repos in the April sweep (AnnouncementsPortlet, basiclti-portlet, FeedbackPortlet, NotificationPortlet, CalendarPortlet, etc.).

## Test plan

- [x] `python3 -c "import json; json.load(open('renovate.json'))"` — JSON valid
- [ ] Renovate parses and re-evaluates the dashboard (verifiable after merge — the four major-bump PRs above should be auto-closed or stop being re-opened)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)