### PR TITLE
docs: add v5.17.3 + backfill v5.17.2 to CHANGES and HISTORY

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,5 +1,15 @@
 ## Next Release
 
+## v5.17.3
+
+- substantial frontend modernization landed in [#2915](https://github.com/uPortal-Project/uPortal/pull/2915):
+  Bootstrap 3 → 5, jQuery upgraded, LESS → SCSS, and Fluid Infusion
+  removed from the `respondr` skin. **Customized skins will need
+  updating** — review your overrides under
+  `uPortal-webapp/src/main/webapp/media/skins/` for `.less` files
+  (now `.scss`), Bootstrap 3/4 class names, and any direct uses of the
+  Fluid library.
+
 ## v5.15.2
 
 - new external storage option (Redis) for sessions; see `README.md` under new uPortal-session submodule

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -10,6 +10,15 @@
   (now `.scss`), Bootstrap 3/4 class names, and any direct uses of the
   Fluid library.
 
+## v5.17.2
+
+- **Java 11 is now the minimum required version.** `sourceCompatibility`
+  was bumped from `1.8` to `11` in `build.gradle`. Deployers running
+  Java 8 must upgrade their JVM before deploying this release. The
+  bump was driven by a CVE fix in a transitive dependency that
+  required Java 11; uPortal-start's Tomcat runtime should already be
+  on Java 11.
+
 ## v5.15.2
 
 - new external storage option (Redis) for sessions; see `README.md` under new uPortal-session submodule

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -50,6 +50,16 @@ provides high-level information about earlier versions of uPortal.
 
   - [All releases](https://github.com/uPortal-Project/uPortal/releases)
 
+  Note: 5.3 through 5.16 are not enumerated below. See the link above
+  for the full list.
+
+### 5.17
+
+  - [5.17.3 29-Apr-2026](https://github.com/uPortal-Project/uPortal/releases/tag/v5.17.3)
+  - [5.17.2 02-Apr-2026](https://github.com/uPortal-Project/uPortal/releases/tag/v5.17.2)
+  - [5.17.1 18-Apr-2025](https://github.com/uPortal-Project/uPortal/releases/tag/v5.17.1)
+  - [5.17.0 24-Sep-2024](https://github.com/uPortal-Project/uPortal/releases/tag/v5.17.0)
+
 ### 5.2
 
   - [5.2.1 06-Aug-2018](https://github.com/uPortal-Project/uPortal/releases/tag/v5.2.1)


### PR DESCRIPTION
## Summary

Catch-up doc updates for the v5.17.3 release that was just cut, plus a backfill for v5.17.2 that was missed when 5.17.2 shipped.

## Changes

- **\`docs/CHANGES.md\`**:
  - Add a \`## v5.17.3\` block under "Next Release" calling out Bill (@Naenyn)'s frontend modernization (#2915). Operators with customized skins need to know:
    - LESS → SCSS (rename + syntax updates needed)
    - Bootstrap 3/4 → 5 (class names changed)
    - Fluid Infusion removed (any custom JS using Fluid will break)
  - **Backfill** a \`## v5.17.2\` block calling out the Java 8 → 11 floor bump (commit \`ebe72972a5\` by @Naenyn, 2026-03-05). Deployers running Java 8 cannot run v5.17.2 or later; this should have been documented when v5.17.2 shipped but wasn't.

- **\`docs/HISTORY.md\`** — file had been silent since v5.2 (2018). Added a \`### 5.17\` section listing 5.17.0 → 5.17.3 with their dates + tag links, plus a note above the per-version sections clarifying that 5.3–5.16 are not enumerated (use the "All releases" link). Backfilling 5.3–5.16 is out of scope; can be done as a separate cleanup.

## Test plan

- [x] Markdown renders cleanly (verified locally)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)