### PR TITLE
docs: drop Docker demo publish step from RELEASE.md

### DIFF
--- a/docs/developer/other/RELEASE.md
+++ b/docs/developer/other/RELEASE.md
@@ -156,22 +156,6 @@ curl -X GET \
 
 Open a Pull Request on `uPortal-start` to update `uPortalVersion` to the new release.
 
-## Publish new docker demo of Quickstart
-
-Publish a new apereo/uPortal-demo Docker image and update the `:latest` tag.
-Prerequisites:
-  - Docker Cloud account (<https://cloud.docker.com>)
-  - Access to post to the apereo Docker group
-  - The uPortal version has been added to `uPortal-start`
-
-```sh
-$ cd {uPortal-start repo}
-$ ./gradlew dockerBuildImageDemo
-$ docker login
-$ docker tag {version in format like 5.1.0} apereo/uportal-demo:latest
-$ docker push apereo/uportal-demo:latest
-```
-
 ## Update Community
 For any non-snapshot release, email an announcement to `uportal-dev`, `uportal-user`, and `jasig-announce`.
   - Be sure to acknowledge those who contributed to the release.


### PR DESCRIPTION
## Summary

The "Publish new docker demo of Quickstart" section of RELEASE.md tells the next releaser to push to \`apereo/uportal-demo:latest\`, but that practice was dropped years ago. Removing the dead step from the runbook so it matches what we actually do.

## Changes

- **\`docs/developer/other/RELEASE.md\`**: drop the \`## Publish new docker demo of Quickstart\` section, including the prerequisites bullet list and the \`./gradlew dockerBuildImageDemo\` + \`docker push\` code block. -16 lines, no other text touched.

## Test plan

- [x] \`docs/developer/other/RELEASE.md\` still renders correctly with section flow Update uPortal-start → Update Community
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)