### PR TITLE
fix: drop dead logback ContextDetachingSCL listener from web.xml

### DIFF
--- a/uPortal-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/web.xml
@@ -28,11 +28,6 @@
 
     <display-name>uPortal</display-name>
 
-    <!-- Needed to remove JMX registration and allow for classloader GC. Should be first listener per http://logback.qos.ch/manual/loggingSeparation.html#hotDeploy -->
-    <listener>
-        <listener-class>ch.qos.logback.classic.selector.servlet.ContextDetachingSCL</listener-class>
-    </listener>
-
     <!--
      | uPortal utility for accessing the WebApplicationContext from code that doesn't have a reference to the ServletContext
      +-->


### PR DESCRIPTION
## Problem

\`uPortal-webapp/src/main/webapp/WEB-INF/web.xml\` registers \`ch.qos.logback.classic.selector.servlet.ContextDetachingSCL\` as a servlet context listener with the comment *"Needed to remove JMX registration and allow for classloader GC. Should be first listener per http://logback.qos.ch/manual/loggingSeparation.html#hotDeploy"*.

The class was part of Logback's J2EE selector machinery and **was removed from Logback in 1.3.x**.

The listener has been a tripwire across the fleet during the 2026-05 release wave: every portlet that bumped Logback to 1.3+ via \`uportal-portlet-parent\` v51 hit \`ClassNotFoundException\` at context startup with this exact listener. uPortal core itself bundles Logback 1.5.32 today and would hit the same wall the moment its current "module-loading-warning-only" behavior tightens (or when Tomcat's \`StandardContext\` switches to strict listener loading).

The listener also has no functional value here — Logback's modern auto-cleanup handles classloader GC and JMX deregistration without needing this hook. The original \`loggingSeparation\` guidance (the URL in the comment) was for using \`LoggerContextSelector\` with hot-deploy of separate webapps, which is not how this portal's logging is set up.

## Changes

- **\`uPortal-webapp/src/main/webapp/WEB-INF/web.xml\`**: remove the \`<listener>ContextDetachingSCL</listener>\` block plus its outdated explanatory comment.

## Test plan

- [x] \`./gradlew :uPortal-webapp:assemble\` succeeds locally on Java 11
- [x] Verified the rebuilt \`uPortal-webapp-5.17.4-SNAPSHOT.war\`'s \`WEB-INF/web.xml\` no longer references the missing class
- [x] Same listener removal pattern landing across the fleet (AnnouncementsPortlet, CalendarPortlet, JasigWidgetPortlets, NewsReaderPortlet, NotificationPortlet, SimpleContentPortlet) as a follow-up to the 2026-05 release wave
- [ ] CI green
- [ ] Post-merge: include in 5.17.4 release