### PR TITLE
fix(skin): drop duplicate Bootstrap 5 includes from respondr skin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.17.4-SNAPSHOT
+version=5.17.4
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.17.4
+version=5.17.5-SNAPSHOT
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common_skin.xml
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common_skin.xml
@@ -36,12 +36,10 @@
     <!-- Bootstrap 5 CSS -->
     <css included="plain">/resource-server/webjars/bootstrap/dist/css/bootstrap.css</css>
     <css included="aggregated">/resource-server/webjars/bootstrap/dist/css/bootstrap.min.css</css>
-    <css>/resource-server/webjars/bootstrap/dist/css/bootstrap.min.css</css>
-    
+
     <!-- Bootstrap 5 JS -->
     <js included="plain">/resource-server/webjars/bootstrap/dist/js/bootstrap.bundle.js</js>
     <js included="aggregated">/resource-server/webjars/bootstrap/dist/js/bootstrap.bundle.min.js</js>
-    <js>/resource-server/webjars/bootstrap/dist/js/bootstrap.bundle.min.js</js>
 
     <js included="plain">/resource-server/webjars/jquery-migrate/dist/jquery-migrate.js</js>
     <js included="aggregated">/resource-server/webjars/jquery-migrate/dist/jquery-migrate.min.js</js>


### PR DESCRIPTION
## Problem

`uPortal-webapp/src/main/webapp/media/skins/respondr/common/common_skin.xml` declared the Bootstrap 5 CSS bundle and the Bootstrap 5 JS bundle **three times each**:

- a `<… included=\"plain\">` variant
- a `<… included=\"aggregated\">` variant
- a third **unqualified** entry that matched both render modes

The unqualified entry caused Bootstrap to load twice in the browser. Two copies of `bootstrap.bundle.js` attach two delegated handlers per dropdown toggle, so a single user click toggled the menu to *open* then immediately back to *closed*. Portlet Options dropdowns appeared dead, and any UX flow gated on opening that menu — favorites add/remove, rate-this-portlet, edit-mode entry — silently broke.

## Goal

Include each Bootstrap asset exactly once per render mode so each click handler attaches once.

## Changes

- Drop the unqualified `<css>bootstrap.min.css</css>` entry from `common_skin.xml`; the `included=\"plain\"` + `included=\"aggregated\"` pair already covers every render mode.
- Drop the matching unqualified `<js>bootstrap.bundle.min.js</js>` entry for the same reason.

## How this snuck in

The duplication landed during the Bootstrap 5 migration when two contributors added the asset from different mental models — *unconditional include* and *mode-qualified include*. Both were applied; neither was removed.

## Verification

Built `uPortal` locally, redeployed the WAR via uPortal-start (`./gradlew :overlays:uPortal:tomcatDeploy`), and ran the uPortal-start Playwright smoke suite (106 tests). With the duplicate present, four dropdown-driven tests fail on intermittent open/close races. With the duplicate removed, all four pass; the suite is green.

Manual sanity check in the browser: opening any portlet's Options menu now stays open until the user clicks elsewhere, instead of closing on the same click that opened it.