### PR TITLE
Comment out / deprecate less

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common.less
@@ -26,36 +26,46 @@
     Bootstrap
     ========================================================================== */
 
-/*
- * NOTE:  Do not change the location of Bootstrap sources lightly;  they must
- * be included in the uPortal.war package.
+/* DEPRECATED: This file is deprecated. Please migrate to SCSS for full Bootstrap 5 functionality.
+ * This file now imports compiled Bootstrap CSS for basic compatibility.
+ * For customization and advanced features, use common.scss instead.
  */
-@import "../../../../webjars/bootstrap/less/bootstrap.less";
+@import "../../../../webjars/bootstrap/dist/css/bootstrap.css";
 
 /* ==========================================================================
    Variables
    ========================================================================== */
+/* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
 @import "less/variables.less";
+*/
 
 /* ==========================================================================
    Utility mixins
    ========================================================================== */
+/* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
 @import "less/mixins.less";
+*/
 
 /* ==========================================================================
    Regions
    ========================================================================== */
+/* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
 @import "less/regions.less";
+*/
 
 /* ==========================================================================
    Gallery
    ========================================================================== */
+/* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
 @import "less/gallery.less";
+*/
 
 /* ==========================================================================
    Native Tags
    ========================================================================== */
+/* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
 @import "less/tags.less";
+*/
 
 /* ==========================================================================
    Namespace: .portal
@@ -78,82 +88,114 @@
   /* ==========================================================================
      Header
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/header.less";
+  */
 
   /* ==========================================================================
      Navigation
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/navigation";
+  */
 
   /* ==========================================================================
      Content
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/content.less";
+  */
 
   /* ==========================================================================
      Portlet
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/portlet.less";
+  */
 
   /* ==========================================================================
      Portlets without chrome
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/no-chrome.less";
+  */
 
   /* ==========================================================================
      Personalization
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/personalization.less";
+  */
 
   /* ==========================================================================
      Portlet Config
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/portlet-manager.less";
+  */
 
   /* ==========================================================================
      Portal Administration
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/portal-admin.less";
+  */
 
   /* ==========================================================================
      Rating
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/rating.less";
+  */
 
   /* ==========================================================================
      Search
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/search.less";
+  */
 
   /* ==========================================================================
      Entity Selector
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/entity-selector.less";
+  */
 
   /* ==========================================================================
      Footer
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/footer.less";
+  */
 
   /* ==========================================================================
      Fluid stop-gap file - This will be removed when Universality and Fluid Components are EOL
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/fluid_stopgap.less";
+  */
 
   /* ==========================================================================
      JSR 168 and JSR 268 css.
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/jsr-168.less";
+  */
 
   /* ==========================================================================
      View styles targeting a single specific view within uPortal.
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/views.less";
+  */
 
   /* ==========================================================================
      Plain css flex and grid layouts.
      ========================================================================== */
+  /* DEPRECATED: SCSS imports commented out - migrate to SCSS for full functionality
   @import "less/grids.less";
+  */
 
   /* ==========================================================================
      jQuery UI Dialog Fixes


### PR DESCRIPTION
This is a quick fix to common.less with comments indicating that less support has been removed due to the Bootstrap 5 upgrade.

Optionally, I believe we could also just remove this file, but keeping it for now in the event there are references to it.