### PR TITLE
refactor(uPortal-webapp): consolidate skin + JSP onto /resource-server/

### DIFF
--- a/docs/developer/other/API.md
+++ b/docs/developer/other/API.md
@@ -85,7 +85,7 @@ Example response:
     "title": "Welcome to uPortal",
     "description": "Description of uPortal.",
     "url": null,
-    "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/text-html.png",
+    "iconUrl": "/resource-server/rs/tango/0.8.90/32x32/mimetypes/text-html.png",
     "faIcon": null,
     "fname": "what-is-uportal",
     "target": null,
@@ -97,7 +97,7 @@ Example response:
     "pithyStaticContent": null,
     "parameters": {
       "mobileIconUrl": "/uPortal/media/skins/icons/mobile/feedback.png",
-      "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/text-html.png",
+      "iconUrl": "/resource-server/rs/tango/0.8.90/32x32/mimetypes/text-html.png",
       "disableDynamicTitle": "true",
       "configurable": "true"
     },

--- a/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/portlet-definition/skin.portlet-definition.xml
+++ b/uPortal-webapp/src/main/resources/org/apereo/portal/tenants/sampledata/portlet-definition/skin.portlet-definition.xml
@@ -42,10 +42,10 @@
     </parameter>
     <parameter>
         <name>iconUrl</name>
-        <value>/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png</value>
+        <value>/resource-server/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png</value>
     </parameter>
     <parameter>
         <name>mobileIconUrl</name>
-        <value>/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png</value>
+        <value>/resource-server/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png</value>
     </parameter>
 </portlet-definition>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/flows/locale-selector/selectLocale.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/flows/locale-selector/selectLocale.jsp
@@ -39,7 +39,7 @@
                       <c:forEach items="${ locales }" var="locale">
                           <li style="list-style:none;padding:0.2em 0 0.2em 0">
                               <input type="radio" name="locale" id="${ fn:escapeXml(locale.code) }" value="${ fn:escapeXml(locale.code) }" ${ locale.code == currentLocale ? "checked" : '' }/>
-                              <img src="/ResourceServingWebapp/rs/famfamfam/flags/${ fn:escapeXml(fn:toLowerCase(locale.locale.country) )}.png"/>
+                              <img src="/resource-server/rs/famfamfam/flags/${ fn:escapeXml(fn:toLowerCase(locale.locale.country) )}.png"/>
                               <label for="${ fn:escapeXml(locale.code) }" class="form-check-label">
                                   ${ fn:escapeXml(locale.displayLanguage) }
                               </label>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/BackgroundPreference/viewBackgroundPreference.jsp
@@ -108,7 +108,7 @@
     }
 
     #${n}background-edit-control .background-edit-button .edit-button-image {
-        background: url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/image_edit.png") no-repeat;
+        background: url("/resource-server/rs/famfamfam/silk/1.3/image_edit.png") no-repeat;
         height: 16px;
         width: 16px;
         display: inline-block;

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/DynamicRespondrSkin/skinConfig.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/DynamicRespondrSkin/skinConfig.jsp
@@ -107,7 +107,6 @@
 </div>
 
 <script language="javascript" type="text/javascript">
-<rs:compressJs>
 (function() {
 
     // De-alias jQuery safely within this self-invoking function
@@ -176,5 +175,4 @@
     });
 
 })();
-</rs:compressJs>
 </script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Invoker/sitemap.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Invoker/sitemap.jsp
@@ -52,7 +52,6 @@
     <li><a href=""><span class="title"></span></a></li>
 </template>
 
-<script src="<rs:resourceURL value="/rs/lodash/4.17.4/lodash.min.js"/>"></script>
 
 <%-- API URL for fetching layout details to build sitemap --%>
 <c:set value="${renderRequest.contextPath}" var="portalContextPath" />
@@ -71,10 +70,29 @@
     if (holder.dataset.sitemapInit) return;
     holder.dataset.sitemapInit = '1';
 
+    // hasPath('a.b.c', obj) — supports the dot-path semantics of lodash _.has
+    function hasPath(obj, dotPath) {
+        var parts = dotPath.split('.');
+        for (var i = 0; i < parts.length; i++) {
+            if (obj == null || typeof obj !== 'object' || !(parts[i] in obj)) {
+                return false;
+            }
+            obj = obj[parts[i]];
+        }
+        return true;
+    }
+    // Decode the small set of HTML entities lodash _.unescape covers.
+    var UNESCAPE_MAP = { '&amp;': '&', '&lt;': '<', '&gt;': '>', '&quot;': '"', '&#39;': "'", '&#96;': '`' };
+    function unescapeHtml(s) {
+        return String(s == null ? '' : s).replace(/&(amp|lt|gt|quot|#39|#96);/g, function (m) {
+            return UNESCAPE_MAP[m];
+        });
+    }
+
     // If a path check fails, it'll throw an error.
     function sitemapJsonCheck(jsonObj, pathChecks, errMsg) {
-        return !_.every(pathChecks, function(pathCheck) {
-            if(!_.has(jsonObj, pathCheck)) {
+        return !pathChecks.every(function (pathCheck) {
+            if (!hasPath(jsonObj, pathCheck)) {
                 console.log(errMsg + pathCheck);
                 return false;
             }
@@ -105,23 +123,23 @@
             // Begin tab row
             var tabRowTemplate = document.getElementById('sitemap-tab-row-template');
             var tabRow = document.importNode(tabRowTemplate.content, true).querySelector('div');
-            _.forEach(response.layout.navigation.tabs, function (tab, tabIndex) {
+            response.layout.navigation.tabs.forEach(function (tab, tabIndex) {
                 if (!sitemapJsonCheck(tab, ['name', 'externalId', 'content'], "Missing required object path [layout.navigation.tabs] > ")) {
                     // Setup tab link
                     var tabTemplate = document.getElementById('sitemap-tab-template');
                     var tabHeader = document.importNode(tabTemplate.content, true).querySelector('div');
                     // Add content to tab header template
                     var tabHeaderLink = tabHeader.querySelector('a');
-                    tabHeaderLink.textContent = _.unescape(tab.name);
+                    tabHeaderLink.textContent = unescapeHtml(tab.name);
                     tabHeaderLink.href = '${portalContextPath}/f/' + tab.externalId + '/normal/render.uP';
                     var portletList = tabHeader.querySelector('ul');
 
-                    _.forEach(tab.content, function (parentContent, parentContentIndex) {
+                    tab.content.forEach(function (parentContent, parentContentIndex) {
                         if (sitemapJsonCheck(parentContent, ['content'], "Missing required object path [layout.navigation.tabs] > content > ")) {
                             return;
                         }
 
-                        _.forEach(parentContent.content, function (portlet, portletIndex) {
+                        parentContent.content.forEach(function (portlet, portletIndex) {
                             if (sitemapJsonCheck(portlet, ['name', 'fname', 'ID'], "Missing required object path [layout.navigation.tabs] > content > content > ")) {
                                 return;
                             }
@@ -131,7 +149,7 @@
                             var portletListItem = document.importNode(portletTemplate.content, true).querySelector('li');
                             // Add content to portlet template
                             var portletTitle = portletListItem.querySelector('span');
-                            portletTitle.textContent = _.unescape(portlet.name);
+                            portletTitle.textContent = unescapeHtml(portlet.name);
                             var portletLink = portletListItem.querySelector('a');
                             portletLink.href = '${portalContextPath}/f/' + tab.externalId + '/p/' + portlet.fname + '.' + portlet.ID + '/max/render.uP';
                             if (portlet.parameters && portlet.parameters.alternativeMaximizedLink) {

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/search.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/search.jsp
@@ -140,7 +140,7 @@
     <c:set var="prepopulateAutoSuggestUrl" value="${pageContext.request.contextPath}${portletPreferencesValues['prepopulateAutoSuggestUrl'][0]}"/>
 </c:if>
 
-<script language="javascript" type="text/javascript"><rs:compressJs>
+<script language="javascript" type="text/javascript">
 (function($) {
 
     $(function() {
@@ -170,4 +170,4 @@
     });
 
 })(up.jQuery);
-</rs:compressJs></script>
+</script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchLauncher.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchLauncher.jsp
@@ -55,7 +55,7 @@
     <c:set var="prepopulateAutoSuggestUrl" value="${pageContext.request.contextPath}${portletPreferencesValues['prepopulateAutoSuggestUrl'][0]}"/>
 </c:if>
 
-<script language="javascript" type="text/javascript"><rs:compressJs>
+<script language="javascript" type="text/javascript">
 (function($) {
 
     $(function() {
@@ -79,4 +79,4 @@
     });
 
 })(up.jQuery);
-</rs:compressJs></script>
+</script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchRest.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Search/searchRest.jsp
@@ -56,7 +56,6 @@
      </div>
 </template>
 
-<script src="<rs:resourceURL value="/rs/lodash/4.17.4/lodash.min.js"/>"></script>
 <style>
     #search-results-tab-header {
         display: inline-block;
@@ -134,6 +133,22 @@
 <spring:message var="i18n_score" code="search.score" />
 
 <script language="javascript" type="text/javascript">
+// "peopleTab" -> "People Tab"; "portlets" -> "Portlets". Sufficient for
+// the camelCase JSON keys this page receives from the search API.
+function startCase(s) {
+    return s.replace(/([a-z])([A-Z])/g, '$1 $2')
+            .replace(/[-_]+/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+}
+// "peopleTab" -> "people-tab"
+function kebabCase(s) {
+    return s.replace(/([a-z])([A-Z])/g, '$1-$2')
+            .replace(/[\s_]+/g, '-')
+            .toLowerCase();
+}
+
 // This metadata object tells us which avatar (icon) and which
 // attribute to use as a primary display name for each result type
 var metadata = {
@@ -175,10 +190,11 @@ fetch('${searchApiUrl}', {credentials: 'same-origin'})
         return response.json();
     })
     .then(function (response) {
-        _.forEach(response, function (resultSet, tabProperty) {
+        Object.keys(response).forEach(function (tabProperty) {
+            var resultSet = response[tabProperty];
             // Generate formatted text
-            var tabName = _.startCase(tabProperty);
-            var tabId = _.kebabCase(tabProperty);
+            var tabName = startCase(tabProperty);
+            var tabId = kebabCase(tabProperty);
             // Setup tab header template
             var tabTemplate = document.getElementById('search-results-tab-header-template');
             var tabHeader = document.importNode(tabTemplate.content, true);
@@ -201,7 +217,7 @@ fetch('${searchApiUrl}', {credentials: 'same-origin'})
                 tabPanel.querySelector('div').appendChild(noResults);
             } else {
                 // add each result from the result set to the panel
-                _.forEach(resultSet, function (result) {
+                resultSet.forEach(function (result) {
                     // setup search result item template
                     var searchResultTemplate = document.getElementById('search-result-item-template');
                     var searchResult = document.importNode(searchResultTemplate.content, true);
@@ -214,15 +230,16 @@ fetch('${searchApiUrl}', {credentials: 'same-origin'})
                         searchResult.querySelector('.up-search-list-item-secondary-content').style.visibility = 'hidden';
                     }
                     var resultAttributeList = searchResult.querySelector('dl');
-                    _.forOwn(result, function(attributeValue, attributeName){
+                    Object.keys(result).forEach(function (attributeName) {
                         // We will only display the items in the i18n list
-                        if (i18n.hasOwnProperty(attributeName)) {
+                        if (Object.prototype.hasOwnProperty.call(i18n, attributeName)) {
+                            var attributeValue = result[attributeName];
                             var translatedAttributeName = i18n[attributeName];
                             // setup attribute pairing template
                             var attributePairTemplate = document.getElementById('search-result-item-detail-template');
                             var attributePair = document.importNode(attributePairTemplate.content, true);
                             // add values
-                            attributePair.querySelector('dt').textContent = _.startCase(translatedAttributeName) + ':';
+                            attributePair.querySelector('dt').textContent = startCase(translatedAttributeName) + ':';
                             attributePair.querySelector('dd').textContent = attributeValue;
                             // add attributes to the result
                             resultAttributeList.appendChild(attributePair);

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/SessionTimeout/header.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/SessionTimeout/header.jsp
@@ -60,7 +60,6 @@
 
 <script src="<c:url value='/scripts/session-timeout.js'/>"></script>
 <script>
-    <rs:compressJs>
         up.SessionTimeoutInstance = up.SessionTimeout({
             enabled: ${enabled},
             sessionTimeoutMS: ${sessionTimeoutMS},
@@ -71,5 +70,4 @@
         });
 
         up.SessionTimeoutInstance.startTimer();
-    </rs:compressJs>
 </script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Statistics/reportGraph.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Statistics/reportGraph.jsp
@@ -23,16 +23,16 @@
 
 <script type="text/javascript" src="//www.google.com/jsapi"></script>
 
-<rs:resourceURL var="rgbcolorScriptPath" value="/rs/canvg/r144/rgbcolor-r144.min.js"/>
+<c:set var="rgbcolorScriptPath" value="/resource-server/rs/canvg/r144/rgbcolor-r144.min.js"/>
 <script type="text/javascript" src="${rgbcolorScriptPath}"></script>
 
-<rs:resourceURL var="canvgScriptPath" value="/rs/canvg/r144/canvg-r144.min.js"/>
+<c:set var="canvgScriptPath" value="/resource-server/rs/canvg/r144/canvg-r144.min.js"/>
 <script type="text/javascript" src="${canvgScriptPath}"></script>
 
-<rs:resourceURL var="base64ScriptPath" value="/rs/canvas2image/base64-1.0.min.js"/>
+<c:set var="base64ScriptPath" value="/resource-server/rs/canvas2image/base64-1.0.min.js"/>
 <script type="text/javascript" src="${base64ScriptPath}"></script>
 
-<rs:resourceURL var="canvas2imageScriptPath" value="/rs/canvas2image/canvas2image-0.1.min.js"/>
+<c:set var="canvas2imageScriptPath" value="/resource-server/rs/canvas2image/canvas2image-0.1.min.js"/>
 <script type="text/javascript" src="${canvas2imageScriptPath}"></script>
 
 <!-- Portlet -->
@@ -114,7 +114,6 @@
 </div>
 
 <script type="text/javascript">
-<rs:compressJs>
 google.load("visualization", "1.0", {
    packages : [ "corechart", "charteditor" ]
 });
@@ -358,5 +357,4 @@ up.jQuery(function() {
    $("#${n}_reportForm select[name=interval]").change(validateIntervals);
 
 });
-</rs:compressJs>
 </script>

--- a/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Translator/translator.jsp
+++ b/uPortal-webapp/src/main/webapp/WEB-INF/jsp/Translator/translator.jsp
@@ -152,7 +152,7 @@
   </div>
   <div class="ui-helper-clearfix"></div>
 
-  <script type="text/javascript"><rs:compressJs>
+  <script type="text/javascript">
   up.jQuery(function($) {
       up.TranslatorPortlet("#${ns}container",  {
           namespace: "<portlet:namespace />",
@@ -175,5 +175,5 @@
           }
       });
   });
-  </rs:compressJs></script>
+  </script>
 </div>

--- a/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/modern-portlet-browser.js
+++ b/uPortal-webapp/src/main/webapp/media/skins/common/javascript/uportal/modern-portlet-browser.js
@@ -248,7 +248,7 @@ class PortletRegistry {
             iconUrl:
                 channel.iconUrl ||
                 channel.parameters?.iconUrl?.value ||
-                '/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-other.png',
+                '/resource-server/rs/tango/0.8.90/32x32/categories/applications-other.png',
         };
     }
 
@@ -476,7 +476,7 @@ class PortletListView {
                 </a>
                 <div class="ri-content portlet-thumb-content ui-helper-clearfix">
                     <div class="ri-titlebar portlet-thumb-titlebar">${portlet.title}</div>
-                    <div class="ri-icon portlet-thumb-icon" style="background: url(${portlet.iconUrl || '/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-other.png'}) top left no-repeat;"><span>Thumbnail</span></div>
+                    <div class="ri-icon portlet-thumb-icon" style="background: url(${portlet.iconUrl || '/resource-server/rs/tango/0.8.90/32x32/categories/applications-other.png'}) top left no-repeat;"><span>Thumbnail</span></div>
                     <div class="ri-description portlet-thumb-description">${portlet.description || ''}</div>
                 </div>
             </div>

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common_skin.xml
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common_skin.xml
@@ -23,8 +23,8 @@
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
 
-    <js included="plain">/ResourceServingWebapp/rs/modernizr/2.6.2/modernizr-2.6.2.js</js>
-    <js included="aggregated">/ResourceServingWebapp/rs/modernizr/2.6.2/modernizr-2.6.2.min.js</js>
+    <!-- modernizr removed 2026-05-06: zero Modernizr.* callsites in workspace,
+         no .no-js/.js class dependencies. Pure dead weight. -->
 
     <!--
     | NOTE:  The following order is important!
@@ -101,21 +101,9 @@
     <css included="plain" resource="true">/webjars/jstree/dist/themes/default/style.css</css>
     <css included="aggregated" resource="true">/webjars/jstree/dist/themes/default/style.min.css</css>
 
-    <!-- ES6&7 polyfill -->
-    <js included="plain" resource="true">/webjars/core-js-bundle/index.js</js>
-    <js included="aggregated" resource="true">/webjars/core-js-bundle/minified.js</js>
-
-    <!-- async await polyfill -->
-    <js included="plain" resource="true">/webjars/regenerator-runtime/runtime.js</js>
-    <js included="aggregated" resource="true">/webjars/regenerator-runtime/runtime.js</js>
-
-    <!-- whatwg fetch polyfill -->
-    <js included="plain" resource="true">/webjars/whatwg-fetch/dist/fetch.umd.js</js>
-    <js included="aggregated" resource="true">/webjars/whatwg-fetch/dist/fetch.umd.js</js>
-
-    <!-- web component polyfill -->
-    <js included="plain" resource="true">/webjars/webcomponents__webcomponentsjs/webcomponents-bundle.js</js>
-    <js included="aggregated" resource="true">/webjars/webcomponents__webcomponentsjs/webcomponents-bundle.js</js>
+    <!-- ES6+/fetch/async-await/Web-Components polyfills removed 2026-05-06.
+         uPortal targets Bootstrap 5 baseline browsers (no IE), all of
+         which natively support these APIs. Polyfills were dead weight. -->
 
 
 

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common_skin.xml
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common_skin.xml
@@ -56,11 +56,11 @@
 
 
 
-    <js included="plain" resource="true">/rs/underscore/1.8.3/underscore.js</js>
-    <js included="aggregated" resource="true">/rs/underscore/1.8.3/underscore.min.js</js>
+    <js included="plain">/resource-server/rs/underscore/1.8.3/underscore.js</js>
+    <js included="aggregated">/resource-server/rs/underscore/1.8.3/underscore.min.js</js>
 
-    <js included="plain" resource="true">/rs/backbone/1.3.3/backbone-1.3.3.js</js>
-    <js included="aggregated" resource="true">/rs/backbone/1.3.3/backbone-1.3.3.min.js</js>
+    <js included="plain">/resource-server/rs/backbone/1.3.3/backbone-1.3.3.js</js>
+    <js included="aggregated">/resource-server/rs/backbone/1.3.3/backbone-1.3.3.min.js</js>
 
     <js included="plain">/resource-server/rs/jquery-plugins/noty/2.4.1/jquery.noty.packaged.js</js>
     <js included="aggregated">/resource-server/rs/jquery-plugins/noty/2.4.1/jquery.noty.packaged.min.js</js>
@@ -76,8 +76,8 @@
     <css included="aggregated">/resource-server/webjars/datatables.net-bs5/css/dataTables.bootstrap5.min.css</css>
 
     <!-- Rating Includes -->
-    <js included="plain" resource="true">/rs/jquery-plugins/rating/1.0/bootstrap-rating-input.js</js>
-    <js included="aggregated" resource="true">/rs/jquery-plugins/rating/1.0/bootstrap-rating-input.min.js</js>
+    <js included="plain">/resource-server/rs/jquery-plugins/rating/1.0/bootstrap-rating-input.js</js>
+    <js included="aggregated">/resource-server/rs/jquery-plugins/rating/1.0/bootstrap-rating-input.min.js</js>
 
     <!-- DataTables SearchPanes for column filtering (modern replacement for ColumnFilterWidgets) -->
     <js included="plain">/resource-server/webjars/datatables.net-searchpanes/js/dataTables.searchPanes.js</js>

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/scss/entity-selector.scss
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/scss/entity-selector.scss
@@ -61,14 +61,14 @@
         color: #248222;
         text-decoration: none;
         background: transparent
-          url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/tick.png") 0 50%
+          url("/resource-server/rs/famfamfam/silk/1.3/tick.png") 0 50%
           no-repeat;
 
         &:hover,
         &:focus {
           color: #9f0000;
           background: #ffc
-            url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/delete.png") 0 50%
+            url("/resource-server/rs/famfamfam/silk/1.3/delete.png") 0 50%
             no-repeat;
         }
       }
@@ -179,7 +179,7 @@
 
       .select {
         background: transparent
-          url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/add.png") 0 50%
+          url("/resource-server/rs/famfamfam/silk/1.3/add.png") 0 50%
           no-repeat;
 
         span {
@@ -215,7 +215,7 @@
       }
 
       .select {
-        background-image: url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/delete.png");
+        background-image: url("/resource-server/rs/famfamfam/silk/1.3/delete.png");
         cursor: pointer;
       }
     }
@@ -223,7 +223,7 @@
     .group {
       .member-list {
         a {
-          background-image: url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/folder.png");
+          background-image: url("/resource-server/rs/famfamfam/silk/1.3/folder.png");
         }
       }
     }
@@ -231,7 +231,7 @@
     .person {
       .member-list {
         span {
-          background-image: url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/vcard.png");
+          background-image: url("/resource-server/rs/famfamfam/silk/1.3/vcard.png");
         }
       }
     }
@@ -239,7 +239,7 @@
     .category {
       .member-list {
         a {
-          background-image: url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/tag_orange.png");
+          background-image: url("/resource-server/rs/famfamfam/silk/1.3/tag_orange.png");
         }
       }
     }
@@ -334,7 +334,7 @@
       a {
         display: block;
         padding: 0 0 0 20px;
-        background: url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/add.png")
+        background: url("/resource-server/rs/famfamfam/silk/1.3/add.png")
           0% 50% no-repeat;
         text-decoration: none;
 
@@ -358,7 +358,7 @@
 
         a {
           color: #248222;
-          background-image: url("/ResourceServingWebapp/rs/famfamfam/silk/1.3/delete.png");
+          background-image: url("/resource-server/rs/famfamfam/silk/1.3/delete.png");
           font-weight: bold;
         }
       }

--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/defaultSkin/skin.xml
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/defaultSkin/skin.xml
@@ -25,13 +25,11 @@
 
   <css>https://fonts.googleapis.com/css?family=Oxygen</css>
 
-  <css included="plain">/ResourceServingWebapp/rs/normalize/2.1.2/normalize-2.1.2.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/normalize/2.1.2/normalize-2.1.2.min.css</css>
+  <!-- normalize.css removed 2026-05-06: Bootstrap 5's reboot.css covers
+       the same browser-default normalization for any BS5-baseline browser. -->
 
-
-
-  <css included="plain">/ResourceServingWebapp/rs/fontawesome/4.7.0/css/font-awesome.css</css>
-  <css included="aggregated">/ResourceServingWebapp/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
+  <css included="plain">/resource-server/rs/fontawesome/4.7.0/css/font-awesome.css</css>
+  <css included="aggregated">/resource-server/rs/fontawesome/4.7.0/css/font-awesome.min.css</css>
 
 
 

--- a/uPortal-webapp/src/test/resources/org/apereo/portal/io/xml/portlet/test_4-0.portlet.xml
+++ b/uPortal-webapp/src/test/resources/org/apereo/portal/io/xml/portlet/test_4-0.portlet.xml
@@ -45,6 +45,6 @@
     </parameter>
     <parameter>
         <name>iconUrl</name>
-        <value>/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-system.png</value>
+        <value>/resource-server/rs/tango/0.8.90/32x32/categories/applications-system.png</value>
     </parameter>
 </portlet-definition>


### PR DESCRIPTION
## Summary

Moves uPortal core's skin descriptors, admin JSPs, and chrome-asset references off the legacy `/ResourceServingWebapp/` context to the modern `/resource-server/`. Also drops a bundle of 2008–2015 utility libraries (lodash 4.17.4, modernizr 2.6.2, normalize.css 2.1.2, four polyfill webjars) that were either CVE-prone, native-replaceable on modern browsers, or both. Removes dead `<rs:compressJs>` taglib wrappers (already a no-op upstream).

Two commits:

1. **`c80cdea43b`** — main consolidation: JSP `<rs:compressJs>` cleanup, skin SCSS path swaps to `/resource-server/`, tango/famfamfam icon URL swaps in the admin chrome and skin, drop the dead utility-lib webjar dependencies. ~30 files.
2. **`0468c6de77`** — finishing touch in `respondr/common/common_skin.xml`: the three `resource="true"` entries (underscore, backbone, jquery-plugins/rating) that the first commit missed are now routed through `/resource-server/`. All three libs are served at byte-identical relative paths under the modern overlay; verified via curl.

## Why

Ahead of the `ResourceServingWebapp` overlay being retired from `uPortal-start`, every reference to `/ResourceServingWebapp/...` in uPortal core needs to land on `/resource-server/...`. The dead `<rs:compressJs>` wrappers (already deprecated by `resource-server-utils` maintainers; minification moved to esbuild) are dead weight in the markup.

## Test plan

- [ ] `./gradlew install` in this repo, then `./gradlew :overlays:uPortal:tomcatDeploy && ./gradlew tomcatStart` in uPortal-start
- [ ] DevTools Network panel on guest welcome, admin home, and `/p/uportal-links/?pCm=config`: zero requests to `/ResourceServingWebapp/...`
- [ ] uPortal-start's Playwright suite (specifically `tests/ux/smoke/visual-resource-server.spec.ts`) passes — that suite asserts the absence of legacy URL requests; companion PR uPortal-Project/uPortal-start#694 extends its coverage to `uportal-links?pCm=config`
- [ ] Visual sanity: portlet thumbnails, admin chrome icons, and the rating widget render unchanged

## Companion PRs

- uPortal-Project/uPortal-start#694 — uPortal-start's side of the consolidation
- JasigWidgetPortlets `9068d91` (release as 2.4.3-SNAPSHOT) drops lodash from `configLinks.jsp` and switches to `/resource-server/`