### PR TITLE
docs(release): prefer keys.openpgp.org over keyserver.ubuntu.com

### DIFF
--- a/docs/developer/other/RELEASE.md
+++ b/docs/developer/other/RELEASE.md
@@ -15,8 +15,19 @@ There are 3 prerequisites to cutting releases:
 4. [Set up public PGP key on a server](https://central.sonatype.org/pages/working-with-pgp-signatures.html)
     - Generate a key pair `gpg2 --gen-key`
     - If you choose to have an expiration date, edit the key via `gpg2 --edit-key {key ID}`
-    - Determine the key ID and keyring file `gpg2 --list-keys` (the key ID is the `pub` ID)
-    - Distribute your public key `gpg2 --keyserver hkp://keyserver.ubuntu.com --send-keys {key ID}`
+    - Determine the key ID and fingerprint via `gpg2 --list-keys` (the key ID is the `pub` ID; the fingerprint is the 40-char hex)
+    - **Publish your key on `keys.openpgp.org`** — the Central Publisher Portal queries this keyserver **first** when validating signatures. A key that is only on `keyserver.ubuntu.com` or other SKS-network servers will fail signature validation non-deterministically (verified against the [Maven portlet release guide](https://github.com/uPortal-Project/uportal-project.github.io/blob/master/manuals/en/uportal5-manual/developer/maven-release-process.md) during the 2026 portlet release cycle).
+        - `keys.openpgp.org` does not accept SKS-style API uploads. Export your public key with `gpg2 --export --armor {fingerprint} > pubkey.asc`, then paste the contents into the web form at <https://keys.openpgp.org/upload> and confirm via the email link they send to your key's UID address. Identity packets are gated behind email confirmation; without it the key publishes but searches against your email won't return it.
+        - Optionally also push to `keyserver.ubuntu.com` as a redundancy: `gpg2 --keyserver hkp://keyserver.ubuntu.com --send-keys {key ID}`
+        - The `pool.sks-keyservers.net` pool was decommissioned in 2021 — do not use it.
+    - **Verify your key is reachable on `keys.openpgp.org`** before every release session:
+
+        ```sh
+        $ curl -so /dev/null -w "%{http_code}\n" \
+            "https://keys.openpgp.org/vks/v1/by-fingerprint/{FINGERPRINT}"
+        ```
+
+        `200` = good. `404` = upload first.
 
 ## Setup
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.17.7
+version=5.17.8-SNAPSHOT
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.17.5-SNAPSHOT
+version=5.17.7
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal


### PR DESCRIPTION
## Summary

- Bring the keyserver step in `docs/developer/other/RELEASE.md` in line with the [Maven portlet release guide](https://github.com/uPortal-Project/uportal-project.github.io/blob/master/manuals/en/uportal5-manual/developer/maven-release-process.md), which the 2026 portlet release cycle confirmed as the working sequence
- Replace the single \`keyserver.ubuntu.com\` line with \`keys.openpgp.org\`-first instructions, the email-confirmation caveat, the optional Ubuntu redundancy, the SKS pool deprecation note, and a per-session verification curl

## Why

The Central Publisher Portal queries \`keys.openpgp.org\` first when validating signatures. A key that's only on \`keyserver.ubuntu.com\` fails signature validation non-deterministically — sometimes the first release in a session works because of caching, then a subsequent one in the same session fails. The Maven ecosystem release guide had already been corrected during the 2026 portlet release cycle; this PR closes the drift between the two guides so operators only set up their key once and have it work for both Gradle and Maven publishing.

## Test plan

- [ ] Render \`docs/developer/other/RELEASE.md\` on GitHub and confirm the new \`keys.openpgp.org\` instructions, curl verification snippet, and cross-link to the Maven guide all display correctly
- [ ] Visually compare against the equivalent section in \`uportal-project.github.io/manuals/en/uportal5-manual/developer/maven-release-process.md\` to confirm the two guides now use the same language