### PR TITLE
docs(release): manual NOTICE/license review step pre-Testing

### DIFF
--- a/docs/developer/other/RELEASE.md
+++ b/docs/developer/other/RELEASE.md
@@ -72,6 +72,21 @@ Ideally, dependencies in all of the above areas should be at the latest versions
 - `resourceServer13Version` - Only in uPortal-start. Should always be at the latest version
 - `personDirectoryVersion` - Should stay in sync across the dependency areas
 
+## Review NOTICE and License Headers
+
+Unlike the Maven-based components in the uPortal ecosystem (see [Maven release process for ecosystem components](https://github.com/uPortal-Project/uportal-project.github.io/blob/master/manuals/en/uportal5-manual/developer/maven-release-process.md)), uPortal's Gradle build does not currently regenerate `NOTICE` or enforce license headers. Until a Gradle equivalent of `mvn notice:generate` / `mvn license:format` is wired in, manually review the following before cutting a release:
+
+- `NOTICE` — copyright year range and contributor list are current
+- `LICENSE` — Apache License 2.0; should not change release-to-release
+- License headers on files added since the last release. A quick heuristic from the component root:
+
+    ```sh
+    $ git diff --name-only v{previous-version}..HEAD -- '*.java' '*.groovy' '*.xml' '*.jsp' | \
+        xargs -I {} sh -c 'head -3 "{}" | grep -q "Licensed to Apereo" || echo "MISSING header: {}"'
+    ```
+
+If anything drifts, commit the corrections — typically `chore: pre-release prep` — before continuing to Testing.
+
 ## Testing
 
 Build a clean version of `uPortal-start` with the quickstart data set and perform at least light testing, especially around features that have been fixed or enhanced.

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.17.7
+version=5.17.8-SNAPSHOT
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.17.5-SNAPSHOT
+version=5.17.7
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal


### PR DESCRIPTION
## Summary

- Add a new "Review NOTICE and License Headers" section to `docs/developer/other/RELEASE.md`, between "Review Dependencies" and "Testing"
- Cross-link the [Maven release process for ecosystem components](https://github.com/uPortal-Project/uportal-project.github.io/blob/master/manuals/en/uportal5-manual/developer/maven-release-process.md) so operators can see the automated equivalent on the Maven side
- Include a quick \`grep\` heuristic for finding files added since the last release that may be missing the Apache license header

## Why

The Maven-based components in the ecosystem have automated NOTICE regeneration and license-header enforcement via `mvn notice:generate` / `mvn license:format` / `mvn javadoc:fix`. uPortal's Gradle build has no equivalent tooling wired in — so the release guide currently provides no prompt for the operator to do the equivalent review by hand. This is a known release-quality risk that surfaced while cross-walking the two release guides.

Until a Gradle equivalent of those plugins is wired in (separate work, separate PR), this PR provides an explicit manual review step so the gap is at least visible to operators.

## Test plan

- [ ] Render `docs/developer/other/RELEASE.md` on GitHub and confirm the new section appears between "Review Dependencies" and "Testing"
- [ ] Confirm the cross-link to the Maven release guide resolves
- [ ] Confirm the `git diff` / `grep` heuristic snippet renders inside the markdown list correctly