### PR TITLE
fix(skin): use @import (inline) for bootstrap.css in common.less

### DIFF
--- a/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common.less
+++ b/uPortal-webapp/src/main/webapp/media/skins/respondr/common/common.less
@@ -30,7 +30,7 @@
  * This file now imports compiled Bootstrap CSS for basic compatibility.
  * For customization and advanced features, use common.scss instead.
  */
-@import "../../../../webjars/bootstrap/dist/css/bootstrap.css";
+@import (inline) "../../../../webjars/bootstrap/dist/css/bootstrap.css";
 
 /* ==========================================================================
    Variables


### PR DESCRIPTION
The LESS compiler treats @import "file.css" as a passthrough, outputting it verbatim as a CSS @import statement rather than inlining the file contents. This causes a 404 at runtime because the relative path resolves incorrectly from the browser's perspective.

Adding the (inline) keyword tells lessc to read and embed the file contents at compile time, where the relative path resolves correctly against the unpacked WAR structure.

This affects any skin still using the LESS compilation path (e.g. institutions that haven't migrated to SCSS yet).