### PR TITLE
fix(deps): drop transitive log4j-core, bridge log4j2 to slf4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ allprojects {
         all*.exclude group: 'commons-logging', module: 'commons-logging'
         all*.exclude group: 'commons-logging', module: 'commons-logging-api'
         all*.exclude group: 'log4j', module: 'log4j'
+        all*.exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
         all*.exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -86,6 +86,7 @@ jsoupVersion=1.22.2
 jspApiVersion=2.3.3
 junitVersion=4.13.2
 lesscssVersion=1.7.0.1.1
+log4j2Version=2.25.4
 logbackVersion=1.5.32
 lombokVersion=1.18.46
 mockitoVersion=4.11.0

--- a/uPortal-webapp/build.gradle
+++ b/uPortal-webapp/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     runtimeOnly "org.jasig.cas.client:cas-client-support-distributed-ehcache:${casClientVersion}"
     runtimeOnly "org.jasig.ehcache:ehcache-jgroups3replication:${ehcacheJgroups3ReplicationVersion}"
     runtimeOnly "org.jasig.portlet.utils:portlet-ws-util:${apereoPortletUtilsVersion}"
+    runtimeOnly "org.apache.logging.log4j:log4j-to-slf4j:${log4j2Version}"
     runtimeOnly "org.slf4j:jul-to-slf4j:${slf4jVersion}"
     runtimeOnly "org.slf4j:log4j-over-slf4j:${slf4jVersion}"
     runtimeOnly "org.springframework.security:spring-security-config:${springSecurityVersion}"


### PR DESCRIPTION
Problem: `grouperClient` pulls `org.apache.logging.log4j:log4j-core` onto the runtime classpath transitively. uPortal logs through slf4j/logback, so log4j-core is both unused and a standing vulnerability surface (the Log4Shell-family CVEs all live in log4j-core).

Goal: remove log4j-core from the runtime classpath while keeping any code that calls the log4j2 API (e.g. grouperClient) logging correctly through the existing slf4j/logback pipeline.

Changes:
- `build.gradle`: globally exclude `org.apache.logging.log4j:log4j-core` from all configurations
- `uPortal-webapp/build.gradle`: add the `log4j-to-slf4j` bridge as a runtime dependency so log4j2 API calls route to slf4j
- `gradle.properties`: pin `log4j2Version=2.25.4` for the bridge

Notes: this is a runtime classpath/dependency change, verified by confirming log4j-core no longer resolves onto the runtime classpath and that startup logging still flows through logback. No automated test accompanies a dependency-exclusion change; CI exercises the build across the Java 11 matrix.