### PR TITLE
build(deps): migrate dynamic-skin S3 storage to AWS SDK v2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,7 @@ portletApiDependency=org.apache.portals:portlet-api_2.1.0_spec:1.0
 
 # Dependency Versions
 antVersion=1.10.17
-awsVersion=1.12.797
+awsVersion=2.46.7
 apereoPortletUtilsVersion=1.1.3
 aspectjVersion=1.9.25.1
 casClientVersion=3.6.2

--- a/uPortal-portlets/build.gradle
+++ b/uPortal-portlets/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api project(':uPortal-tenants')
     api project(':uPortal-web')
 
-    implementation "com.amazonaws:aws-java-sdk-s3:${awsVersion}"
+    implementation "software.amazon.awssdk:s3:${awsVersion}"
     implementation "javax.mail:mail:${javaxMailVersion}"
     implementation("net.sf.json-lib:json-lib-ext-spring:${jsonLibExtSpringVersion}") {
         exclude group: 'javax.servlet', module: 'servlet-api'

--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/dynamicskin/storage/s3/AwsCredentialsConfig.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/dynamicskin/storage/s3/AwsCredentialsConfig.java
@@ -14,24 +14,21 @@
  */
 package org.apereo.portal.portlets.dynamicskin.storage.s3;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSCredentialsProviderChain;
-import com.amazonaws.services.s3.AmazonS3Client;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
 /**
  * Class to encapsulate the AWS credential properties, with the properties read in from a properties
- * file and auto-injected by Spring. This class implements the {@link AWSCredentials} interface and
- * can therefore be injected as credentials into a {@link AmazonS3Client}. If a credential property
- * has no value in the properties file, then it's value will be set to null so that this class can
- * be returned by a {@link AWSCredentialsProvider} as part of a {@link AWSCredentialsProviderChain},
- * which expects null values to be returned when the provider is unable to find credentials.
+ * file and auto-injected by Spring. This class implements the {@link AwsCredentials} interface and
+ * can therefore be supplied as credentials to an S3 client via an {@link AwsCredentialsProvider}.
+ * The credential properties are optional; when unset they resolve to null so the default provider
+ * chain can be used instead.
  */
 @Component
-public class AwsCredentialsConfig implements AWSCredentials {
+public class AwsCredentialsConfig implements AwsCredentials {
 
     @Value("${dynamic-skin.aws.access-key-id:#{null}}")
     private String accessKeyId;
@@ -39,26 +36,18 @@ public class AwsCredentialsConfig implements AWSCredentials {
     @Value("${dynamic-skin.aws.secret-access-key:#{null}}")
     private String secretAccessKey;
 
-    public String getAccessKey() {
+    @Override
+    public String accessKeyId() {
         return this.accessKeyId;
     }
 
-    public String getSecretAccessKey() {
+    @Override
+    public String secretAccessKey() {
         return this.secretAccessKey;
     }
 
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
-    }
-
-    @Override
-    public String getAWSAccessKeyId() {
-        return this.accessKeyId;
-    }
-
-    @Override
-    public String getAWSSecretKey() {
-        return this.secretAccessKey;
     }
 }

--- a/uPortal-portlets/src/main/java/org/apereo/portal/portlets/dynamicskin/storage/s3/AwsS3DynamicSkinService.java
+++ b/uPortal-portlets/src/main/java/org/apereo/portal/portlets/dynamicskin/storage/s3/AwsS3DynamicSkinService.java
@@ -14,21 +14,13 @@
  */
 package org.apereo.portal.portlets.dynamicskin.storage.s3;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.AmazonWebServiceRequest;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
-import javax.portlet.PortletPreferences;
 import net.sf.ehcache.Cache;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -46,6 +38,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 
 /** {@link DynamicSkinService} implementation that saves the CSS to an AWS S3 bucket. */
 @Service("awsS3DynamicSkinService")
@@ -66,13 +68,13 @@ public class AwsS3DynamicSkinService extends AbstractDynamicSkinService {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private AmazonS3 amazonS3Client;
+    private S3Client amazonS3Client;
     private DynamicSkinAwsS3BucketConfig awsS3BucketConfig;
     private Map<String, String> awsObjectUserMetadata;
 
     @Autowired
     public AwsS3DynamicSkinService(
-            final AmazonS3 client,
+            final S3Client client,
             final DynamicSkinAwsS3BucketConfig config,
             final DynamicSkinUniqueTokenGenerator uniqueTokenGenerator,
             final DynamicSkinCssFileNamer namer,
@@ -111,7 +113,7 @@ public class AwsS3DynamicSkinService extends AbstractDynamicSkinService {
                 ATTEMPTING_TO_GET_FILE_METADATA_FROM_AWS_S3_LOG_MSG,
                 this.awsS3BucketConfig.getBucketName(),
                 objectKey);
-        final ObjectMetadata metadata = this.getMetadataFromAwsS3Bucket(objectKey);
+        final HeadObjectResponse metadata = this.getMetadataFromAwsS3Bucket(objectKey);
         log.info(
                 FILE_METADATA_RETRIEVED_FROM_AWS_S3_LOG_MSG,
                 this.awsS3BucketConfig.getBucketName(),
@@ -119,28 +121,33 @@ public class AwsS3DynamicSkinService extends AbstractDynamicSkinService {
         if (metadata == null) {
             return false;
         } else {
+            // S3 returns user-metadata keys lower-cased, so look up with the lower-cased key.
             final String uniqueTokenFromS3 =
-                    metadata.getUserMetaDataOf(SKIN_UNIQUE_TOKEN_METADATA_KEY);
+                    metadata.metadata()
+                            .get(SKIN_UNIQUE_TOKEN_METADATA_KEY.toLowerCase(Locale.ROOT));
             return this.getUniqueToken(data).equals(uniqueTokenFromS3);
         }
     }
 
-    private ObjectMetadata getMetadataFromAwsS3Bucket(final String objectKey) {
-        final GetObjectMetadataRequest request =
-                new GetObjectMetadataRequest(this.awsS3BucketConfig.getBucketName(), objectKey);
+    private HeadObjectResponse getMetadataFromAwsS3Bucket(final String objectKey) {
+        final HeadObjectRequest request =
+                HeadObjectRequest.builder()
+                        .bucket(this.awsS3BucketConfig.getBucketName())
+                        .key(objectKey)
+                        .build();
         try {
-            return this.amazonS3Client.getObjectMetadata(request);
-        } catch (AmazonServiceException ase) {
-            if (ase.getStatusCode() == 404) {
+            return this.amazonS3Client.headObject(request);
+        } catch (NoSuchKeyException nske) {
+            return null;
+        } catch (S3Exception se) {
+            if (se.statusCode() == 404) {
                 return null;
             }
-            this.logAmazonServiceException(ase, request);
-            throw new DynamicSkinException(
-                    "AWS S3 'get object metadata' failure for: " + request, ase);
-        } catch (AmazonClientException ace) {
-            this.logAmazonClientException(ace, request);
-            throw new DynamicSkinException(
-                    "AWS S3 'get object metadata' failure for: " + request, ace);
+            this.logAwsServiceException(se, request);
+            throw new DynamicSkinException("AWS S3 'head object' failure for: " + request, se);
+        } catch (SdkException sdke) {
+            this.logSdkException(sdke, request);
+            throw new DynamicSkinException("AWS S3 'head object' failure for: " + request, sdke);
         }
     }
 
@@ -161,105 +168,104 @@ public class AwsS3DynamicSkinService extends AbstractDynamicSkinService {
 
     private void saveContentToAwsS3Bucket(
             final String objectKey, final String content, final DynamicSkinInstanceData data) {
-        final InputStream inputStream = IOUtils.toInputStream(content);
-        final ObjectMetadata objectMetadata = this.createObjectMetadata(content, data);
         final PutObjectRequest putObjectRequest =
-                this.createPutObjectRequest(objectKey, inputStream, objectMetadata);
+                this.createPutObjectRequest(objectKey, content, data);
         log.info(
                 ATTEMPTING_TO_SAVE_FILE_TO_AWS_S3_LOG_MSG,
                 this.awsS3BucketConfig.getBucketName(),
                 objectKey);
-        this.saveContentToAwsS3Bucket(putObjectRequest);
+        this.saveContentToAwsS3Bucket(putObjectRequest, content);
         log.info(FILE_SAVED_TO_AWS_S3_LOG_MSG, this.awsS3BucketConfig.getBucketName(), objectKey);
     }
 
-    private ObjectMetadata createObjectMetadata(
-            final String content, final DynamicSkinInstanceData data) {
-        final ObjectMetadata metadata = new ObjectMetadata();
-        this.addContentMetadata(metadata, content);
-        this.addUserMetatadata(metadata);
-        this.addPortletPreferenceMetadata(metadata, data.getPortletRequest().getPreferences());
-        this.addDynamicSkinMetadata(metadata, data);
-        return metadata;
-    }
-
     private PutObjectRequest createPutObjectRequest(
-            final String objectKey,
-            final InputStream inputStream,
-            final ObjectMetadata objectMetadata) {
-        return new PutObjectRequest(
-                this.awsS3BucketConfig.getBucketName(), objectKey, inputStream, objectMetadata);
+            final String objectKey, final String content, final DynamicSkinInstanceData data) {
+        final byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+        final PutObjectRequest.Builder builder =
+                PutObjectRequest.builder()
+                        .bucket(this.awsS3BucketConfig.getBucketName())
+                        .key(objectKey)
+                        .contentType("text/css")
+                        .contentLength((long) contentBytes.length)
+                        .contentMD5(this.calculateBase64EncodedMd5Digest(contentBytes))
+                        .metadata(this.buildUserMetadata(data));
+        final String cacheControl = this.resolveCacheControl(data);
+        if (cacheControl != null) {
+            builder.cacheControl(cacheControl);
+        }
+        return builder.build();
     }
 
-    private void saveContentToAwsS3Bucket(final PutObjectRequest putObjectRequest) {
+    private void saveContentToAwsS3Bucket(
+            final PutObjectRequest putObjectRequest, final String content) {
         try {
-            this.amazonS3Client.putObject(putObjectRequest);
-        } catch (AmazonServiceException ase) {
-            this.logAmazonServiceException(ase, putObjectRequest);
+            this.amazonS3Client.putObject(
+                    putObjectRequest, RequestBody.fromString(content, StandardCharsets.UTF_8));
+        } catch (S3Exception se) {
+            this.logAwsServiceException(se, putObjectRequest);
             throw new DynamicSkinException(
-                    "AWS S3 'put object' failure for: " + putObjectRequest, ase);
-        } catch (AmazonClientException ace) {
-            this.logAmazonClientException(ace, putObjectRequest);
+                    "AWS S3 'put object' failure for: " + putObjectRequest, se);
+        } catch (SdkException sdke) {
+            this.logSdkException(sdke, putObjectRequest);
             throw new DynamicSkinException(
-                    "AWS S3 'put object' failure for: " + putObjectRequest, ace);
+                    "AWS S3 'put object' failure for: " + putObjectRequest, sdke);
         }
     }
 
-    private void addContentMetadata(final ObjectMetadata metadata, final String content) {
-        metadata.setContentMD5(this.calculateBase64EncodedMd5Digest(content));
-        metadata.setContentLength(content.length());
-        metadata.setContentType("text/css");
-        final String cacheControl = this.awsS3BucketConfig.getObjectCacheControl();
-        if (StringUtils.isNotEmpty(cacheControl)) {
-            metadata.setCacheControl(cacheControl);
-        }
-    }
-
-    private String calculateBase64EncodedMd5Digest(final String content) {
+    private String calculateBase64EncodedMd5Digest(final byte[] content) {
         final byte[] md5DigestAs16ElementByteArray = DigestUtils.md5(content);
         return new String(Base64.encodeBase64(md5DigestAs16ElementByteArray));
     }
 
-    private void addUserMetatadata(final ObjectMetadata metadata) {
+    private Map<String, String> buildUserMetadata(final DynamicSkinInstanceData data) {
+        final Map<String, String> userMetadata = new HashMap<>();
         if (this.awsObjectUserMetadata != null) {
-            for (Entry<String, String> entry : this.awsObjectUserMetadata.entrySet()) {
-                metadata.addUserMetadata(entry.getKey(), entry.getValue());
-            }
+            userMetadata.putAll(this.awsObjectUserMetadata);
         }
+        userMetadata.put(SKIN_UNIQUE_TOKEN_METADATA_KEY, this.getUniqueToken(data));
+        return userMetadata;
     }
 
-    private void addPortletPreferenceMetadata(
-            final ObjectMetadata metadata, final PortletPreferences portletPreferences) {
+    /**
+     * Resolves the cache-control value to apply: the bucket config value when non-empty, overridden
+     * by the per-portlet preference when that preference is set. Returns null when neither applies.
+     */
+    private String resolveCacheControl(final DynamicSkinInstanceData data) {
+        String cacheControl = null;
+        final String configCacheControl = this.awsS3BucketConfig.getObjectCacheControl();
+        if (StringUtils.isNotEmpty(configCacheControl)) {
+            cacheControl = configCacheControl;
+        }
         final String contentCacheControl =
-                portletPreferences.getValue(CONTENT_CACHE_CONTROL_PORTLET_PREF_NAME, null);
+                data.getPortletRequest()
+                        .getPreferences()
+                        .getValue(CONTENT_CACHE_CONTROL_PORTLET_PREF_NAME, null);
         if (contentCacheControl != null) {
-            metadata.setCacheControl(contentCacheControl);
+            cacheControl = contentCacheControl;
         }
+        return cacheControl;
     }
 
-    private void addDynamicSkinMetadata(
-            final ObjectMetadata metadata, final DynamicSkinInstanceData data) {
-        metadata.addUserMetadata(SKIN_UNIQUE_TOKEN_METADATA_KEY, this.getUniqueToken(data));
-    }
-
-    private void logAmazonClientException(
-            final AmazonClientException exception, final AmazonWebServiceRequest request) {
+    private void logSdkException(final SdkException exception, final SdkRequest request) {
         log.info(
-                "Caught an AmazonClientException, which means the client encountered a serious internal problem "
+                "Caught an SdkException, which means the client encountered a serious internal problem "
                         + "while trying to communicate with S3, such as not being able to access the network.");
         log.info("Error Message: {}", exception.getMessage());
     }
 
-    private void logAmazonServiceException(
-            final AmazonServiceException exception, final AmazonWebServiceRequest request) {
+    private void logAwsServiceException(
+            final AwsServiceException exception, final SdkRequest request) {
         log.info(
-                "Caught an AmazonServiceException, which means your request made it "
+                "Caught an AwsServiceException, which means your request made it "
                         + "to Amazon S3, but was rejected with an error response for some reason.");
         log.info("Error Message:    {}", exception.getMessage());
-        log.info("HTTP Status Code: {}", exception.getStatusCode());
-        log.info("AWS Error Code:   {}", exception.getErrorCode());
-        log.info("Error Type:       {}", exception.getErrorType());
-        log.info("Request ID:       {}", exception.getRequestId());
+        log.info("HTTP Status Code: {}", exception.statusCode());
+        log.info(
+                "AWS Error Code:   {}",
+                exception.awsErrorDetails() != null
+                        ? exception.awsErrorDetails().errorCode()
+                        : null);
+        log.info("Request ID:       {}", exception.requestId());
     }
 
     public void setAwsObjectUserMetadata(final Map<String, String> metadata) {

--- a/uPortal-portlets/src/test/java/org/apereo/portal/portlets/dynamicskin/storage/s3/AwsS3DynamicSkinServiceTest.java
+++ b/uPortal-portlets/src/test/java/org/apereo/portal/portlets/dynamicskin/storage/s3/AwsS3DynamicSkinServiceTest.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to Apereo under one or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information regarding copyright ownership. Apereo
+ * licenses this file to you under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the License at the
+ * following location:
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apereo.portal.portlets.dynamicskin.storage.s3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+import net.sf.ehcache.Cache;
+import org.apereo.portal.portlets.dynamicskin.DynamicSkinInstanceData;
+import org.apereo.portal.portlets.dynamicskin.DynamicSkinUniqueTokenGenerator;
+import org.apereo.portal.portlets.dynamicskin.storage.DynamicSkinCssFileNamer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+public class AwsS3DynamicSkinServiceTest {
+
+    private static final String TOKEN = "tok-123";
+
+    @Mock private S3Client s3Client;
+    @Mock private DynamicSkinAwsS3BucketConfig config;
+    @Mock private DynamicSkinUniqueTokenGenerator tokenGenerator;
+    @Mock private DynamicSkinCssFileNamer namer;
+    @Mock private Cache failureCache;
+    @Mock private DynamicSkinInstanceData data;
+    @Mock private PortletRequest portletRequest;
+    @Mock private PortletPreferences preferences;
+
+    private AwsS3DynamicSkinService service;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        given(this.config.getBucketName()).willReturn("skin-bucket");
+        given(this.config.getObjectKeyPrefix()).willReturn("skins");
+        given(this.namer.generateCssFileName(this.data)).willReturn("myskin.css");
+        given(this.tokenGenerator.generateToken(this.data)).willReturn(TOKEN);
+        given(this.data.getPortletRequest()).willReturn(this.portletRequest);
+        given(this.portletRequest.getPreferences()).willReturn(this.preferences);
+        this.service =
+                new AwsS3DynamicSkinService(
+                        this.s3Client,
+                        this.config,
+                        this.tokenGenerator,
+                        this.namer,
+                        this.failureCache);
+    }
+
+    @Test
+    public void putsCssWithExpectedKeyContentTypeMetadataAndCacheControl() throws Exception {
+        given(this.config.getObjectCacheControl()).willReturn("public, max-age=3600");
+        given(
+                        this.preferences.getValue(
+                                AwsS3DynamicSkinService.CONTENT_CACHE_CONTROL_PORTLET_PREF_NAME,
+                                null))
+                .willReturn(null);
+        final String content = "body { color: red; }";
+        final File tempCss = File.createTempFile("skin", ".css");
+        tempCss.deleteOnExit();
+        Files.write(tempCss.toPath(), content.getBytes(StandardCharsets.UTF_8));
+
+        this.service.moveCssFileToFinalLocation(this.data, tempCss);
+
+        ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(this.s3Client).putObject(captor.capture(), any(RequestBody.class));
+        PutObjectRequest request = captor.getValue();
+        assertEquals("skin-bucket", request.bucket());
+        assertEquals("skins/myskin.css", request.key());
+        assertEquals("text/css", request.contentType());
+        assertEquals("public, max-age=3600", request.cacheControl());
+        assertEquals(Long.valueOf(content.length()), request.contentLength());
+        assertEquals(
+                TOKEN,
+                request.metadata().get(AwsS3DynamicSkinService.SKIN_UNIQUE_TOKEN_METADATA_KEY));
+    }
+
+    @Test
+    public void cssFileExistsWhenHeadObjectReturnsMatchingToken() {
+        // S3 returns user-metadata keys lower-cased.
+        given(this.s3Client.headObject(any(HeadObjectRequest.class)))
+                .willReturn(
+                        HeadObjectResponse.builder()
+                                .metadata(Collections.singletonMap("dynamicskinuniquetoken", TOKEN))
+                                .build());
+
+        assertTrue(this.service.innerSkinCssFileExists(this.data));
+    }
+
+    @Test
+    public void cssFileDoesNotExistWhenObjectMissing() {
+        given(this.s3Client.headObject(any(HeadObjectRequest.class)))
+                .willThrow(NoSuchKeyException.builder().build());
+
+        assertFalse(this.service.innerSkinCssFileExists(this.data));
+    }
+}

--- a/uPortal-webapp/src/main/resources/properties/contexts/portlet/DynamicRespondrSkin-portlet.xml
+++ b/uPortal-webapp/src/main/resources/properties/contexts/portlet/DynamicRespondrSkin-portlet.xml
@@ -57,17 +57,19 @@
      |        </portlet-preference>
      +-->
     <!--
-    <bean id="amazonS3Client" class="com.amazonaws.services.s3.AmazonS3Client">
+    <bean id="amazonS3Client" class="software.amazon.awssdk.services.s3.S3Client" factory-method="create" />
     -->
         <!--
-         | Uncomment this only if the aws-credentials.properties file (or an overrides.properties file) will be used to retrieve the
-         | credentials. Otherwise, the default behavior (which searches a number of sources) will be used.
-         | See: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Client.html#AmazonS3Client()
+         | The bean above (AWS SDK v2) uses the default credentials and region provider chains
+         | (environment, system properties, profile, container/instance metadata). Note: v2 resolves
+         | the region strictly and fails fast if none is found, so ensure AWS_REGION (or the
+         | aws.region system property) is set. To supply credentials from the dynamic-skin.aws.*
+         | properties instead, build the client in a @Configuration class with a
+         | StaticCredentialsProvider wrapping the awsCredentialsConfig bean, e.g.
+         |   S3Client.builder()
+         |       .credentialsProvider(StaticCredentialsProvider.create(awsCredentialsConfig))
+         |       .build();
          +-->
-         <!--<constructor-arg ref="awsCredentialsConfig" />-->
-    <!--
-    </bean>
-    -->
 
     <bean parent="primaryPropertyPlaceholderConfigurer" />
 


### PR DESCRIPTION
Problem: `uPortal-portlets` depends on AWS SDK **v1** (`com.amazonaws:aws-java-sdk-s3` 1.12.797) for the dynamic-skin S3 storage backend. AWS has placed SDK v1 **out of security support**. (Companion to SimpleContentPortlet#563, which migrates the other v1 S3 usage in the fleet.)

Goal: move the dynamic-skin S3 storage to the supported AWS SDK v2 with no change to stored object layout, metadata, or returned URLs.

Changes:
- `gradle.properties` / `uPortal-portlets/build.gradle`: replace `com.amazonaws:aws-java-sdk-s3` with `software.amazon.awssdk:s3`, set `awsVersion=2.46.7`.
- `AwsS3DynamicSkinService`: rebuild the put on the v2 builder API (`PutObjectRequest.builder` + `RequestBody.fromString`); replace the v1 `getObjectMetadata` existence check with `headObject`, treating `NoSuchKeyException` / HTTP 404 as "absent"; build content fields + a user-metadata `Map` on the request; preserve cache-control resolution (bucket config overridden by portlet preference); look up the unique-token user-metadata with a **lower-cased** key (S3 lower-cases user-metadata keys).
- `AwsCredentialsConfig`: implement v2 `AwsCredentials` (`accessKeyId`/`secretAccessKey`) instead of the v1 `AWSCredentials` interface.
- `DynamicRespondrSkin-portlet.xml`: update the commented-out, deployer-enabled S3 client example to the v2 `S3Client` factory + a note on v2 region resolution and `StaticCredentialsProvider` wiring.
- add `AwsS3DynamicSkinServiceTest` (Mockito) covering the put-request shape and the `headObject` existence check (present + missing).

Verification: `:uPortal-portlets:test` green (3/3); `verGJF` passes; `dependency:tree` confirms `apache5-client` (v2 sync HTTP client) present and commons-logging absent.

**This S3 backend is off by default** — the `storage.s3` package is excluded from component scan and the client bean is commented out — so default deployments are unaffected.

⚠️ **Deployer-facing behavior change** (only for deployers who enable the S3 skin backend): v2 resolves region strictly via the default chain (`AWS_REGION` / profile / instance metadata) and fails fast if none is set, whereas v1 sometimes defaulted to `us-east-1`.