### PR TITLE
fix(jgroups): clear JDBC_PING table on view change

### DIFF
--- a/uPortal-webapp/src/main/resources/properties/jgroups.xml
+++ b/uPortal-webapp/src/main/resources/properties/jgroups.xml
@@ -43,12 +43,16 @@
     />
 
     <!-- User database for discovery;  initialize_sql to blank prevents
-         table creation, which we handle with Hibernate via dbloader -->
+         table creation, which we handle with Hibernate via dbloader.
+         clear_table_on_view_change has the coordinator wipe the table on
+         each view change so live members re-register and rows left behind
+         by abruptly terminated (e.g. kill -9) nodes do not accumulate. -->
     <JDBC_PING
             connection_url="${jgroups.connection.url}"
             connection_username="${jgroups.connection.username}"
             connection_password="${jgroups.connection.password}"
             connection_driver="${jgroups.connection.driver_class}"
+            clear_table_on_view_change="true"
             initialize_sql=""
     />
     <MERGE3  min_interval="5000"


### PR DESCRIPTION
Problem: the `JDBC_PING` discovery table accumulates stale rows over time. A node that terminates abruptly (e.g. `kill -9`) never deregisters, so its row lingers and the table grows with zombie entries across restarts.

Goal: keep the discovery table reflecting only live members so abandoned rows do not accumulate.

Changes:
- set `clear_table_on_view_change="true"` on the `JDBC_PING` element in `uPortal-webapp/src/main/resources/properties/jgroups.xml`, so the coordinator wipes the table on each view change and live members re-register
- expand the surrounding comment to explain the behavior

Notes: configuration-only change; no automated test is feasible since the behavior is multi-node JGroups cluster discovery, which CI does not exercise.