### PR TITLE
build(signing): sign releases via the gpg command (useGpgCmd)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,13 @@ subprojects {
         required { gradle.taskGraph.hasTask('uploadArchives') }
         sign configurations.archives
     }
+    // `useGpgCmd()` makes the gpg command an always-present signatory, so the Sign
+    // tasks would otherwise run on CI (gpg is installed) with no key and fail. `required`
+    // only governs enforcement, not execution — gate the tasks themselves so they run
+    // only when a release is actually uploading artifacts.
+    tasks.withType(Sign).configureEach {
+        onlyIf { gradle.taskGraph.hasTask('uploadArchives') }
+    }
     tasks.withType(Javadoc).all {
         // disable JavaDocs until we start using them again in our website
         enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,12 @@ subprojects {
         publishingRepositoryUrlSnapshot = project.hasProperty('ossrhUrlSnapshot') ? project.getProperty('ossrhUrlSnapshot') : "https://central.sonatype.com/repository/maven-snapshots/"
     }
     signing {
+        // Sign via the gpg command + gpg-agent (like the Maven ecosystem components),
+        // rather than reading an in-process secring.gpg. gpg-agent supplies the
+        // passphrase (pinentry), so no signing.password is stored in a properties file,
+        // and the modern GnuPG keystore is used. Select the key with the
+        // `signing.gnupg.keyName` Gradle property (e.g. in ~/.gradle/gradle.properties).
+        useGpgCmd()
         required { gradle.taskGraph.hasTask('uploadArchives') }
         sign configurations.archives
     }


### PR DESCRIPTION
Problem: the Gradle `signing` block signs in-process from the legacy `~/.gnupg/secring.gpg` keyring (`signing.keyId` / `signing.secretKeyRingFile` / `signing.password`). Modern GnuPG (2.1+) keeps secret keys in its own keystore, **not** `secring.gpg`, so a key thats in the keystore and published to keys.openpgp.org can be absent from `secring.gpg`. This diverged from the Maven ecosystem components (which sign through the `gpg` command + gpg-agent) and forces the signing passphrase into a properties file.

Concretely, cutting v5.17.9 hit this: the published signing key was in the modern keystore but not in `secring.gpg`, so `signArchives` failed with `did not find secret key ... in key source file: secring.gpg`.

Goal: sign uPortal releases the same way the Maven components do — via `gpg` + gpg-agent — so the modern keystore and the already-published key are used, with no passphrase stored in a file.

Changes:
- `build.gradle`: add `useGpgCmd()` to the `signing` block. Signing shells out to `gpg`; the key is selected via the `signing.gnupg.keyName` Gradle property.

Verification: build configures cleanly (`./gradlew help`). Signing is still gated on `uploadArchives`, so normal builds and CI are unaffected; actual signing is exercised at release time (gpg-agent prompts via pinentry).

**Releaser note:** set `signing.gnupg.keyName=<key>` in `~/.gradle/gradle.properties` (e.g. the fleets keys.openpgp.org-published key). The old `signing.keyId` / `signing.password` / `signing.secretKeyRingFile` are no longer used by this build.