### PR TITLE
chore: advance master to 5.17.10-SNAPSHOT after v5.17.9 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.17.9-SNAPSHOT
+version=5.17.9
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 # TODO:  Change to org.apereo.portal
 group=org.jasig.portal
-version=5.17.9
+version=5.17.10-SNAPSHOT
 
 # Project Metadata (NB:  copied from CAS;  may or may not be used by us;  review later)
 projectUrl=https://www.apereo.org/projects/uPortal


### PR DESCRIPTION
Problem: the v5.17.9 release was cut with `release-uportal.sh` (Gradle `net.researchgate.release`). That plugin pushes its release commits to the **branch tracking remote (the fork, `origin`)**, and the script pushes only the **tag** to upstream. As a result, `upstream/master` received the `v5.17.9` tag but **not** the two release commits, so it is stuck at `5.17.9-SNAPSHOT` while the release (5.17.9) has already shipped. The next release prep would mis-compute the version from a stale base.

Goal: advance `upstream/master` to `5.17.10-SNAPSHOT`, matching the released `v5.17.9` tag.

Changes (the two standard release-plugin commits):
- `[Gradle Release Plugin] - pre tag commit: 'v5.17.9'`
- `[Gradle Release Plugin] - new version commit: 'v5.17.10-SNAPSHOT'`

Net effect: `gradle.properties` `version` 5.17.9-SNAPSHOT → 5.17.10-SNAPSHOT.

Notes: this is the post-release master advance. Follow-up: `release-uportal.sh` should push master to upstream alongside the tag (and use `--force` on its tag fetch) so this manual sync is not needed next time — tracked separately.