### PR TITLE
chore(release): harden release-uportal.sh (force tag fetch, push branch to upstream)

### DIFF
--- a/release-uportal.sh
+++ b/release-uportal.sh
@@ -57,7 +57,7 @@ Phases:
      -Prelease.useAutomaticVersion=true / -Prelease.releaseVersion=<X.Y.Z>
      / -Prelease.newVersion=<X.Y.Z+1>-SNAPSHOT
   8. OSSRH POST — push staged repo into Central Portal staging UI
-  9. Push tag to upstream — the Gradle release plugin only pushes to origin
+  9. Push tag + branch to upstream — the Gradle release plugin only pushes to origin
  10. Print next steps (Publish in Portal UI, watch propagation)
 
 NOTE on NOTICE/license tooling: uPortal's Gradle build does not currently

--- a/release-uportal.sh
+++ b/release-uportal.sh
@@ -104,7 +104,9 @@ CURRENT=$(git rev-parse --abbrev-ref HEAD)
 [[ "$CURRENT" == "$BRANCH" ]] || fail "on '$CURRENT', expected '$BRANCH'"
 ok "on branch $BRANCH"
 
-git fetch upstream "$BRANCH" --tags --quiet
+# --force so a stale local tag (e.g. one re-cut on upstream during an earlier
+# release) can't fail the fetch and silently abort the script under `set -e`.
+git fetch upstream "$BRANCH" --tags --force --quiet
 LOCAL_HEAD=$(git rev-parse HEAD)
 UPSTREAM_HEAD=$(git rev-parse "upstream/$BRANCH")
 if [[ "$LOCAL_HEAD" != "$UPSTREAM_HEAD" ]]; then
@@ -227,10 +229,14 @@ HTTP=$(curl -s -o /tmp/release-ossrh.out -w "%{http_code}" -X POST \
 [[ "$HTTP" == "200" ]] || fail "OSSRH POST HTTP $HTTP (see /tmp/release-ossrh.out)"
 ok "OSSRH POST: HTTP 200"
 
-# 9. Push tag to upstream — the Gradle release plugin only pushes to origin
-hdr "Push v$RELEASE tag to upstream"
+# 9. Push tag + branch to upstream — the Gradle release plugin only pushes to
+#    origin (the fork), so without this upstream gets the tag but not the two
+#    release commits, leaving upstream/$BRANCH behind and mis-basing the next
+#    release's version. Push both.
+hdr "Push v$RELEASE tag + $BRANCH to upstream"
 git push upstream "v$RELEASE"
-ok "v$RELEASE tag on upstream"
+git push upstream "$BRANCH"
+ok "v$RELEASE tag + $BRANCH on upstream"
 
 # 10. Next steps
 cat <<EOF


### PR DESCRIPTION
Problem: two rough edges surfaced cutting v5.17.9.

1. The tree-state `git fetch upstream <branch> --tags` had **no `--force`**, so a stale local tag (one re-cut on upstream during an earlier release) made the fetch exit non-zero and — under `set -euo pipefail` — **silently aborted the whole script** right after the "on branch master" check.
2. Phase 9 pushed **only the tag** to upstream. The Gradle release plugin (`net.researchgate.release`) pushes its two release commits to `origin` (the fork), so upstream got the tag but stayed behind on the branch — mis-basing the next release's version and forcing a manual sync PR (that was #3004).

Goal: leave upstream fully consistent after a release, and don't abort on stale local tags.

Changes (`release-uportal.sh`):
- add `--force` to the tree-state tag fetch
- push the branch to upstream alongside the tag in phase 9 (`git push upstream "$BRANCH"`)

Verification: `bash -n` clean. `release-portlet.sh` (Maven) shares the `--force`-fetch gap but **not** the push-branch one (maven-release-plugin already pushes master to upstream via `scm.developerConnection`); propagating the fetch fix to the portlet scripts is a separate per-repo change.