### PR TITLE
fix: remove capture-phase click handler that blocks Bootstrap dropdown

### DIFF
--- a/uPortal-webapp/src/main/webapp/scripts/portal-analytics.js
+++ b/uPortal-webapp/src/main/webapp/scripts/portal-analytics.js
@@ -116,18 +116,7 @@
 
                 const existingInstance = bootstrap.Dropdown.getInstance(toggle);
                 if (existingInstance) existingInstance.dispose();
-                const instance = new bootstrap.Dropdown(toggle);
-
-                // Add click handler to override conflicting JavaScript
-                toggle.addEventListener(
-                    'click',
-                    function (event_) {
-                        event_.preventDefault();
-                        event_.stopPropagation();
-                        instance.toggle();
-                    },
-                    true
-                );
+                new bootstrap.Dropdown(toggle);
             }
         }, 100);
     });


### PR DESCRIPTION
The Bootstrap 5 dropdown compatibility fix in portal-analytics.js registered a capture-phase click handler that called stopPropagation() and preventDefault(), preventing Bootstrap's own delegated handler from receiving the event. This caused portlet Options dropdowns to never open on click.

Remove the custom click handler and let Bootstrap's native data-bs-toggle="dropdown" mechanism work unimpeded. The Dropdown instance is still created to ensure initialization.