### PR TITLE
build: force modern commons-lang3 on the plugin classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,19 @@
+buildscript {
+    // The nebula.lint plugin pulls commons-lang3:3.8.1 transitively (via
+    // maven-artifact) onto the plugin classpath, which is a parent of every
+    // subproject buildscript classloader. Parent-first class loading means
+    // that 3.8.1 shadows the newer commons-lang3 declared on subproject
+    // buildscript classpaths (e.g. the resource aggregator used by
+    // uPortal-webapp:aggregateRespondrSkins). 3.8.1 predates
+    // StringUtils.getIfEmpty (added in lang3 3.10), which commons-compress
+    // 1.28+ calls, so force a modern lang3 on the plugin classpath.
+    configurations.classpath {
+        resolutionStrategy {
+            force "org.apache.commons:commons-lang3:${commonsLang3Version}"
+        }
+    }
+}
+
 plugins {
     // Top level plugins
     id 'com.github.kt3k.coveralls' version '2.12.2'


### PR DESCRIPTION
##### Description of change

**Problem:** the `nebula.lint` plugin pulls `commons-lang3:3.8.1` transitively (via `maven-artifact`) onto the Gradle plugin classpath, which is a parent of every subproject buildscript classloader. Because Java class loading is parent-first, that `3.8.1` shadows the newer `commons-lang3` declared on subproject buildscript classpaths — including the resource aggregator used by `uPortal-webapp:aggregateRespondrSkins`.

`3.8.1` predates `StringUtils.getIfEmpty` (added in lang3 3.10), which `commons-compress` 1.28+ calls. So bumping `commons-compress` to 1.28.0 currently fails the skin aggregation task with:

```
Execution failed for task ':uPortal-webapp:aggregateRespondrSkins'.
> 'java.lang.CharSequence org.apache.commons.lang3.StringUtils.getIfEmpty(java.lang.CharSequence, java.util.function.Supplier)'
```

**Goal:** force a modern `commons-lang3` on the plugin classpath so the aggregator resolves the expected API, independent of what `nebula.lint` drags in.

**Change**
- add a root `buildscript { }` block forcing `commons-lang3` to `${commonsLang3Version}` on the plugin `classpath` configuration

**Notes**
- This is a standalone build-robustness fix. On its own it is behaviorally a no-op today (nothing on `master` yet calls `getIfEmpty`), but it unblocks the pending `commons-compress` 1.28.0 update.
- It is independent of the Gradle version — verified on the current Gradle 6.9.4 wrapper as well as a local Gradle 8.5 branch. `buildEnvironment` confirms the force resolves (`commons-lang3:3.8.1 -> 3.20.0`).

**Verified** on JDK 11 / Gradle 6.9.4:
- `./gradlew --no-daemon --no-parallel build`: green (1045 executed, 966 passed, 79 skipped)
- `./gradlew verGJF`: green

_Prepared with the help of an AI coding assistant._