### PR TITLE
build: use hibernateVersion property in hibernate4-dialects

### DIFF
--- a/uPortal-hibernate/uPortal-hibernate4-dialects/build.gradle
+++ b/uPortal-hibernate/uPortal-hibernate4-dialects/build.gradle
@@ -2,7 +2,7 @@ description = "Apereo uPortal Useful Dialects for hibernate 4"
 
 
 dependencies {
-    compileOnly 'org.hibernate:hibernate-core:4.2.+'
+    compileOnly "org.hibernate:hibernate-core:${hibernateVersion}"
     compileOnly "org.slf4j:jcl-over-slf4j:${slf4jVersion}"
 }
 


### PR DESCRIPTION
##### Description of change

**Problem:** the `uPortal-hibernate4-dialects` module pinned `hibernate-core` to the dynamic range `4.2.+`, while the rest of the repo — including the sibling `uPortal-hibernate` module — tracks the `hibernateVersion` property (now `4.3.11.Final`). That stale `4.2.+` reference left this one module a major-minor behind the rest of the build, and it's why Renovate kept opening hibernate 4.x update PRs against it (e.g. #3011): it's the only remaining `4.2.x` reference in the tree.

**Goal:** align the straggler with the repo-wide version and stop the recurring PRs.

**Change**
- `uPortal-hibernate/uPortal-hibernate4-dialects/build.gradle`: point the `compileOnly` `hibernate-core` dependency at `${hibernateVersion}` (matching the sibling `uPortal-hibernate` module) instead of the hardcoded `4.2.+` range, so it stays aligned and cannot drift again.

**Notes**
- This is a consistency fix, not a CVE remediation. The hibernate SQL-injection advisories Renovate attaches to the 4.x line (CVE-2020-25638, CVE-2019-14900) are only fixed in hibernate 5.3.18+/5.4.x, which is out of reach on the current Spring 4.3 baseline. This change does not claim to resolve those.

**Verified** on JDK 11 / Gradle 6.9.4:
- `hibernate-core` now resolves to `4.3.11.Final` on the module's compileClasspath (dependencyInsight)
- `./gradlew :uPortal-hibernate:uPortal-hibernate4-dialects:compileJava`: green

_Prepared with the help of an AI coding assistant._