### PR TITLE
fix(deps): override fast-uri to patched version for CVE-2026-76172

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2041,11 +2041,21 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
-      "license": "MIT"
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "stylelint-config-standard-scss": "^13.1.0",
     "stylelint-prettier": "^5.0.0"
   },
+  "overrides": {
+    "fast-uri": "^3.1.6"
+  },
   "workspaces": [
     "uPortal-webapp/"
   ],


### PR DESCRIPTION
##### Description of change

**Problem:** `fast-uri` is pulled in transitively (`stylelint` → `table` → `ajv`) at **3.0.1**, which is affected by **CVE-2026-76172** ([GHSA-jqff-g426-hqxp](https://github.com/advisories/GHSA-jqff-g426-hqxp), medium). `fast-uri` decodes the URI scheme component with the legacy global `unescape()` and re-serializes it without re-escaping or validating it against the RFC 3986 scheme grammar. A crafted scheme (e.g. `%2f%2fevil.example:/pwn`, the `%uXXXX` form, or one containing `%0d%0a`) can therefore introduce authority structure or a raw CR/LF that the original input did not contain. Callers that `normalize()`/`resolve()` untrusted URLs before a redirect check, host allowlist, or outbound request — especially ones that treat a missing authority as same-origin — can be steered to an attacker-chosen authority, and a normalized URI placed in a response header can carry an injected CR/LF.

**Goal:** pull `fast-uri` up to a patched version. The v3 line is fixed in **3.1.6**.

**Change**
- `package.json`: add an `overrides` entry pinning `fast-uri` to `^3.1.6`. `fast-uri` is not a direct dependency, so an override is the appropriate mechanism rather than a version bump.
- `package-lock.json`: regenerated — `fast-uri` now resolves to **3.1.7**.

**Notes**
- `ajv`'s `^3.0.1` constraint is satisfied by 3.1.7, so no consumer breaks.
- `fast-uri` is a dev/lint-time dependency here (via `stylelint`); it is not shipped in the portal runtime. This clears the advisory regardless.
- `npm audit` no longer reports the advisory after the change.

**Verified** (Node/npm):
- `npm ls fast-uri` → `fast-uri@3.1.7` under `stylelint → table → ajv`
- `npm audit` no longer flags GHSA-jqff-g426-hqxp

_Prepared with the help of an AI coding assistant._