### PR TITLE
fix(deps): bump immutable to 5.1.9 for CVE-2026-59880 et al

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2324,9 +2324,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
##### Description of change

**Problem:** `immutable` (Immutable.js) is pulled in transitively via the `uPortal-webapp` workspace (`sass` → `immutable`) and was locked at **5.1.5**, which is affected by three advisories:

- **CVE-2026-29063** ([GHSA](https://github.com/advisories/GHSA)) — prototype pollution in `mergeDeep()` / `merge()` and related APIs. Fixed in 5.1.5.
- **CVE-2026-59879** — `List` 32-bit trie overflow causing an unrecoverable denial of service (infinite loop / heap exhaustion). Fixed in the 5.x line.
- **CVE-2026-59880** — hash-collision algorithmic-complexity (hash-flooding) DoS in `Map`/`Set`. Fixed in **5.1.8**.

The controlling one is CVE-2026-59880, which requires **≥ 5.1.8** on the v5 line; 5.1.5 is still vulnerable.

**Change**
- `package-lock.json`: refresh the resolved `immutable` version from 5.1.5 to **5.1.9**.

**Why lockfile-only (no `package.json` change):** `immutable` is not a direct dependency. Its consumer, `sass`, already declares a caret range (`^5.1.5`) that permits the patched 5.1.9, so the fix is simply to resolve it in the lockfile (`npm update immutable`). A root `overrides` entry does not reach dependencies inside the workspace tree, so it isn't the right mechanism here.

**Notes**
- `immutable` is a build-time dependency (SCSS compilation via `sass`); it is not shipped in the portal runtime. This clears the advisories regardless.
- The 5.1.9 resolution is stable across a subsequent `npm install`.

**Verified** (Node/npm):
- `npm ls immutable` → `immutable@5.1.9` under `uPortal-webapp → sass`
- `npm audit` no longer reports immutable or any of the three CVEs

_Prepared with the help of an AI coding assistant._